### PR TITLE
🚀 Make it a Git extension

### DIFF
--- a/bin/git-gtr
+++ b/bin/git-gtr
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec gtr "$@"


### PR DESCRIPTION
To make a Git extension, all you need to do is have a CLI named `git-*` in `$PATH` and it'll work. So, if we just have two executable files (one `gtr` and one `git-gtr`), then it'll be possible to use it like `git gtr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `git-gtr` executable command providing a new way to interact with Git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->