### PR TITLE
feat: add Droid AI adapter and Zsh completion support

### DIFF
--- a/adapters/ai/droid.sh
+++ b/adapters/ai/droid.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Droid AI adapter
+
+# Check if Droid is available
+ai_can_start() {
+  command -v droid >/dev/null 2>&1
+}
+
+# Start Droid in a directory
+# Usage: ai_start path [args...]
+ai_start() {
+  local path="$1"
+  shift
+
+  if ! ai_can_start; then
+    log_error "Droid not found. Install from https://github.com/factory-droid/droid"
+    return 1
+  fi
+
+  if [ ! -d "$path" ]; then
+    log_error "Directory not found: $path"
+    return 1
+  fi
+
+  (cd "$path" && droid "$@")
+}

--- a/completions/gtr.zsh
+++ b/completions/gtr.zsh
@@ -1,0 +1,81 @@
+#!/usr/bin/env zsh
+# Zsh completion for gtr
+
+# Load the completion function
+_gtr() {
+  local -a commands
+  commands=(
+    'new:Create a new worktree'
+    'go:Navigate to worktree'
+    'rm:Remove worktree(s)'
+    'editor:Open worktree in editor'
+    'ai:Start AI coding tool'
+    'ls:List all worktrees'
+    'list:List all worktrees'
+    'clean:Remove stale worktrees'
+    'doctor:Health check'
+    'adapter:List available adapters'
+    'config:Manage configuration'
+    'version:Show version'
+    'help:Show help'
+  )
+
+  local -a branches all_options
+  # Get branch names
+  branches=(${(f)"$(git branch --format='%(refname:short)' 2>/dev/null)"})
+  # Add special ID '1' for main repo
+  all_options=("1" "${branches[@]}")
+
+  if (( CURRENT == 2 )); then
+    _describe 'commands' commands
+  elif (( CURRENT == 3 )); then
+    case "$words[2]" in
+      go|editor|ai|rm)
+        _describe 'branch names' all_options
+        ;;
+      new)
+        _arguments \
+          '--from[Base ref]:ref:' \
+          '--track[Track mode]:mode:(auto remote local none)' \
+          '--no-copy[Skip file copying]' \
+          '--no-fetch[Skip git fetch]' \
+          '--force[Allow same branch in multiple worktrees]' \
+          '--name[Custom folder name suffix]:name:' \
+          '--yes[Non-interactive mode]'
+        ;;
+      config)
+        _values 'config action' get set unset
+        ;;
+    esac
+  elif (( CURRENT >= 4 )); then
+    case "$words[2]" in
+      rm)
+        _arguments \
+          '--delete-branch[Delete branch]' \
+          '--force[Force removal even if dirty]' \
+          '--yes[Non-interactive mode]'
+        ;;
+      config)
+        case "$words[3]" in
+          get|set|unset)
+            _values 'config key' \
+              'gtr.worktrees.dir' \
+              'gtr.worktrees.prefix' \
+              'gtr.defaultBranch' \
+              'gtr.editor.default' \
+              'gtr.ai.default' \
+              'gtr.copy.include' \
+              'gtr.copy.exclude' \
+              'gtr.hook.postCreate' \
+              'gtr.hook.postRemove'
+            ;;
+        esac
+        ;;
+    esac
+  fi
+}
+
+_gtr "$@"
+
+# Register completion
+compdef _gtr gtr


### PR DESCRIPTION
## Overview
Add support for Droid AI tool integration and Zsh shell completions to gtr.

## Changes
- **New File: adapters/ai/droid.sh** - AI adapter following the existing adapter pattern
  - Implements `ai_can_start()` to check if Droid is installed
  - Implements `ai_start(path, args...)` to launch Droid in a worktree directory
  - Enables `gtr ai` command to start Droid in worktrees

- **New File: completions/gtr.zsh** - Zsh shell completion file
  - Provides tab completion for all gtr commands
  - Completes branch names and special ID '1' for main repo
  - Completes flags and config keys for all commands

## Usage
After installation, users can:
1. Set Droid as default: `gtr config set gtr.ai.default droid`
2. Launch in worktree: `gtr ai my-feature`
3. Source completions: `source path/to/completions/gtr.zsh`

## Related
- Follows the established adapter pattern from existing AI tool adapters (Claude, Aider, etc.)
- Completes the shell completion suite (Bash, Zsh, Fish now all supported)
- Aligns with gtr's design principle: 'Configuration over flags'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Droid integration: Execute Droid commands within any directory with built-in validation and error handling for missing executables or invalid paths
  * Shell completion enhancements: Zsh completions for gtr command now provide intelligent multi-level argument suggestions, branch name recommendations, and command-specific options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->