### PR TITLE
feat: add opencode adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ gtr.editor.default = cursor
 ### AI Tool Settings
 
 ```bash
-# Default AI tool: none (or aider, claude, codex, cursor, continue)
+# Default AI tool: none (or aider, claude, codex, cursor, continue, opencode)
 gtr.ai.default = none
 ```
 
@@ -328,6 +328,7 @@ gtr.ai.default = none
 | **[Codex CLI](https://github.com/openai/codex)**  | `npm install -g @openai/codex`                    | OpenAI coding assistant              | `git gtr config set gtr.ai.default codex`    |
 | **[Cursor](https://cursor.com)**                  | Install from cursor.com                           | AI-powered editor with CLI agent     | `git gtr config set gtr.ai.default cursor`   |
 | **[Continue](https://continue.dev)**              | See [docs](https://docs.continue.dev/cli/install) | Open-source coding agent             | `git gtr config set gtr.ai.default continue` |
+| **[OpenCode](https://opencode.ai)**               | Install from opencode.ai                          | AI coding assistant                  | `git gtr config set gtr.ai.default opencode` |
 
 **Examples:**
 

--- a/adapters/ai/opencode.sh
+++ b/adapters/ai/opencode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# OpenCode adapter
+
+# Check if OpenCode is available
+ai_can_start() {
+  command -v opencode >/dev/null 2>&1
+}
+
+# Start OpenCode in a directory
+# Usage: ai_start path [args...]
+ai_start() {
+  local path="$1"
+  shift
+
+  if ! ai_can_start; then
+    log_error "OpenCode not found. Install from https://opencode.ai"
+    log_info "Make sure the 'opencode' CLI is available in your PATH"
+    return 1
+  fi
+
+  if [ ! -d "$path" ]; then
+    log_error "Directory not found: $path"
+    return 1
+  fi
+
+  # Change to the directory and run opencode with any additional arguments
+  (cd "$path" && opencode "$@")
+}
+

--- a/bin/gtr
+++ b/bin/gtr
@@ -944,7 +944,7 @@ load_ai_adapter() {
 
   if ! command -v "$cmd_name" >/dev/null 2>&1; then
     log_error "AI tool '$ai_tool' not found"
-    log_info "Built-in adapters: aider, claude, codex, cursor, continue"
+    log_info "Built-in adapters: aider, claude, codex, cursor, continue, opencode"
     log_info "Or use any AI tool command available in your PATH (e.g., bunx, gpt)"
     exit 1
   fi
@@ -1098,7 +1098,7 @@ CONFIGURATION OPTIONS:
                            atom, none
   gtr.ai.default           Default AI tool
                            Options: aider, claude, codex, cursor,
-                           continue, none
+                           continue, opencode, none
   gtr.copy.include         Files to copy (multi-valued)
   gtr.copy.exclude         Files to exclude (multi-valued)
   gtr.copy.includeDirs     Directories to copy (multi-valued)


### PR DESCRIPTION
## Summary
Adds support for OpenCode to gtr.

## Testing
Tested locally on MacOS.

- [x] Create worktree with branch name
- [x] Create worktree with branch containing slashes (e.g., feature/auth)
- [x] Create from remote branch
- [x] Create from local branch
- [x] Create new branch
- [ ] ~~Open in editor (if testing adapters)~~
- [x] Run AI tool (if testing adapters)
- [x] Remove worktree by branch name
- [x] List worktrees
- [x] Test configuration commands
- [x] Test completions (tab completion works)
- [x] Test `gtr go 1` for main repo
- [x] Test `gtr go <branch>` for worktrees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode as a selectable AI tool adapter (can be chosen as the default).

* **User Experience**
  * Adapter will check for OpenCode availability and provide informative guidance if the tool is not installed or cannot be run.

* **Documentation**
  * Updated help text and documentation to list OpenCode among available AI tool choices and in built-in adapter listings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->