### PR TITLE
Fix Claude adapter to support shell function definitions

### DIFF
--- a/adapters/ai/claude.sh
+++ b/adapters/ai/claude.sh
@@ -14,22 +14,18 @@ find_claude_executable() {
 
   # Try to find executable using type -P (Bash/Zsh)
   for cmd in claude claude-code; do
-    if command -v type >/dev/null 2>&1; then
-      local exe_path
-      exe_path="$(type -P "$cmd" 2>/dev/null)" && [ -n "$exe_path" ] && {
-        echo "$exe_path"
-        return 0
-      }
-    fi
+    local exe_path
+    exe_path="$(type -P "$cmd" 2>/dev/null)" && [ -n "$exe_path" ] && {
+      echo "$exe_path"
+      return 0
+    }
   done
 
-  # Fallback: use command -v but exclude functions
+  # Fallback: use type -t to check if it's an executable file
   for cmd in claude claude-code; do
-    if type "$cmd" 2>/dev/null | grep -qv "function"; then
-      if command -v "$cmd" >/dev/null 2>&1; then
-        echo "$cmd"
-        return 0
-      fi
+    if [ "$(type -t "$cmd" 2>/dev/null)" = "file" ]; then
+      command -v "$cmd"
+      return 0
     fi
   done
 


### PR DESCRIPTION
## Problem

When users define `claude` as a shell function (e.g., a wrapper around `~/.claude/local/claude`), the Claude adapter fails with "Claude Code not found" error. This happens because shell functions are not inherited by subshells.

Users often wrap the Claude CLI in a shell function to set environment variables (like HTTP headers for authentication) or customize the execution environment:

```bash
claude () {
    (
        export ANTHROPIC_API_KEY="your-key"
        ~/.claude/local/claude "$@"
    )
}
```

## Solution

This PR adds a `find_claude_executable()` helper function that:

1. Checks common installation paths first - Directly tests `~/.claude/local/claude` (the typical installation location)
2. Uses `type -P` to find executable files only - Excludes shell functions and aliases (Bash/Zsh compatible)
3. Provides fallback logic - Uses `command -v` with function detection for compatibility

Both `ai_can_start()` and `ai_start()` now use this helper to find the actual executable path, ensuring the adapter works correctly even when `claude` is defined as a shell function.

## Testing

Tested with `claude` defined as a shell function. The adapter now correctly:
- Detects the executable at `~/.claude/local/claude`
- Executes it successfully in the worktree directory
- No longer shows "Claude Code not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the tool's executable detection and startup logic for more reliable initialization across environments.

* **Bug Fixes**
  * Unified startup path to avoid runtime branching, reducing startup errors.
  * Added early validation and clearer user-facing error messages when the required executable cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->