### PR TITLE
fix: silence branch track output in auto mode

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -375,7 +375,7 @@ create_worktree() {
         log_step "Branch '$branch_name' exists on remote"
 
         # Create tracking branch first for explicit upstream configuration
-        if git branch --track "$branch_name" "origin/$branch_name" 2>/dev/null; then
+        if git branch --track "$branch_name" "origin/$branch_name" >/dev/null 2>&1; then
           log_info "Created local branch tracking origin/$branch_name"
         fi
 


### PR DESCRIPTION
## Description

Silence `git branch --track` output in auto mode so `create_worktree` returns only the worktree path.

## Motivation

In ‎`track_mode=auto` with a remote-only branch, ‎`git branch --track` printed to stdout, which was concatenated into ‎`WORKTREE_PATH`; postCreate hooks then failed when ‎`cd "$WORKTREE_PATH"` was interpreted as ‎`cd Branch ...`; this change keeps stdout clean by discarding the tracking command output.

Fixes #32 

## Type of Change

<!-- Check all that apply -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

<!-- Describe the tests you ran to verify your changes -->

### Manual Testing Checklist

**Tested on:**

- [x] macOS
- [ ] Linux (specify distro: **\*\***\_**\*\***)
- [ ] Windows (Git Bash)

**Core functionality tested:**

- [x] `git gtr new <branch>` - Create worktree
- [ ] `git gtr go <branch>` - Navigate to worktree
- [ ] `git gtr editor <branch>` - Open in editor (if applicable)
- [ ] `git gtr ai <branch>` - Start AI tool (if applicable)
- [ ] `git gtr rm <branch>` - Remove worktree
- [ ] `git gtr list` - List worktrees
- [ ] `git gtr config` - Configuration commands (if applicable)
- [ ] Other commands affected by this change: **\*\***\_\_**\*\***

### Test Steps

1. Ensure branch exists on origin only (no local branch); 
2.  Run ‎`git gtr new <branch>` (track_mode=auto); 
3. Confirm ‎`WORKTREE_PATH` equals the created worktree path with no extra text
4. Run postCreate hook or ‎`cd "$WORKTREE_PATH"`; it succeeds.

**Expected behavior:**

`create_worktree` stdout is just the worktree path; hooks can `cd` successfully.

**Actual behavior:**

Matches expected after the change.

## Breaking Changes

<!-- If this introduces breaking changes, describe: -->
<!-- - What breaks -->
<!-- - Why it's necessary -->
<!-- - Migration path for users -->

- [ ] This PR introduces breaking changes
- [ ] I have discussed this in an issue first
- [ ] Migration guide is included in documentation

## Checklist

Before submitting this PR, please check:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed manual testing on at least one platform
- [ ] I have updated documentation (README.md, CLAUDE.md, etc.) if needed
- [ ] My changes work on multiple platforms (or I've noted platform-specific behavior)
- [ ] I have added/updated shell completions (if adding new commands or flags)
- [x] I have tested with both `git gtr` (production) and `./bin/gtr` (development)
- [x] No new external dependencies are introduced (Bash + git only)
- [x] All existing functionality still works

## Additional Context

<!-- Add any other context, screenshots, or information about the PR here -->

---

## License Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache License 2.0](../LICENSE.txt).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor internal maintenance update with no end-user visible changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->