### PR TITLE
fix: add # to sanitize_branch_name to prevent shebang issues

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -24,7 +24,7 @@ sanitize_branch_name() {
 
   # Replace slashes, spaces, and other problematic chars with hyphens
   # Remove any leading/trailing hyphens
-  printf "%s" "$branch" | sed -e 's/[\/\\ :*?"<>|]/-/g' -e 's/^-*//' -e 's/-*$//'
+  printf "%s" "$branch" | sed -e 's/[\/\\ :*?"<>|#]/-/g' -e 's/^-*//' -e 's/-*$//'
 }
 
 # Canonicalize a path to its absolute form, resolving symlinks


### PR DESCRIPTION
## Summary

- Add `#` to the list of characters sanitized in branch names
- Prevents Python venv shebang truncation when `#` appears in folder paths

## Related Issue

Closes #43

## Changes

`lib/core.sh` - `sanitize_branch_name()`:
```diff
-  printf "%s" "$branch" | sed -e 's/[\/\\ :*?"<>|]/-/g' -e 's/^-*//' -e 's/-*$//'
+  printf "%s" "$branch" | sed -e 's/[\/\\ :*?"<>|#]/-/g' -e 's/^-*//' -e 's/-*$//'
```

## Test performed

- Created worktree with branch `feature/issue#123`
- Confirmed folder name is `feature-issue-123`
- Verified Python venv works correctly in the worktree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved branch name handling to properly format names containing special characters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->