### PR TITLE
fix: preserve symlinks when copying directories

### DIFF
--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -284,8 +284,8 @@ EOF
       # Create parent directory
       mkdir -p "$dest_parent"
 
-      # Copy directory (cp -r copies the directory itself into dest_parent)
-      if cp -r "$dir_path" "$dest_parent/" 2>/dev/null; then
+      # Copy directory (cp -RP preserves symlinks as symlinks)
+      if cp -RP "$dir_path" "$dest_parent/" 2>/dev/null; then
         log_info "Copied directory $dir_path"
         copied_count=$((copied_count + 1))
 


### PR DESCRIPTION
# Pull Request

## Description

Use `cp -RP` instead of `cp -r` in `copy_directories()` to prevent symlink dereferencing, which breaks dependency manager binaries (e.g., `node_modules/.bin/*`).

## Motivation

When copying directories like `node_modules` to new worktrees, symlinks were being dereferenced into regular files. This breaks executables that rely on symlinks (common in npm/pnpm/yarn).

Fixes #45

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

### Manual Testing Checklist

**Tested on:**

- [x] macOS
- [ ] Linux (specify distro: _______)
- [ ] Windows (Git Bash)

**Core functionality tested:**

- [x] `git gtr new <branch>` - Create worktree
- [ ] `git gtr go <branch>` - Navigate to worktree
- [ ] `git gtr editor <branch>` - Open in editor (if applicable)
- [ ] `git gtr ai <branch>` - Start AI tool (if applicable)
- [ ] `git gtr rm <branch>` - Remove worktree
- [ ] `git gtr list` - List worktrees
- [x] `git gtr config` - Configuration commands (if applicable)
- [ ] Other commands affected by this change: N/A

### Test Steps

1. Create test directory with symlinks:
   ```bash
   mkdir -p test-deps/real-package
   echo "console.log('test')" > test-deps/real-package/index.js
   mkdir -p test-deps/.bin
   ln -s ../real-package/index.js test-deps/.bin/my-cli
   ```

2. Configure gtr to copy the directory:
   ```bash
   git gtr config set gtr.copy.includeDirs test-deps --local
   ```

3. Create a worktree:
   ```bash
   git gtr new test-symlink
   ```

4. Verify symlinks are preserved:
   ```bash
   ls -la "$(git gtr go test-symlink)/test-deps/.bin/"
   ```

**Expected behavior:** Symlink preserved (`lrwxr-xr-x -> ../real-package/index.js`)

**Actual behavior:** Symlink preserved (`lrwxr-xr-x -> ../real-package/index.js`)

## Breaking Changes

- [ ] This PR introduces breaking changes
- [x] I have discussed this in an issue first
- [ ] Migration guide is included in documentation

## Checklist

Before submitting this PR, please check:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed manual testing on at least one platform
- [ ] I have updated documentation (README.md, CLAUDE.md, etc.) if needed
- [ ] My changes work on multiple platforms (or I've noted platform-specific behavior)
- [ ] I have added/updated shell completions (if adding new commands or flags)
- [x] I have tested with both `git gtr` (production) and `./bin/gtr` (development)
- [x] No new external dependencies are introduced (Bash + git only)
- [x] All existing functionality still works

## Additional Context

`cp -RP` is POSIX-compliant and supported on macOS, Linux (GNU coreutils), FreeBSD, and OpenBSD.

---

## License Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache License 2.0](../LICENSE.txt).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed symlink handling during directory copy operations. Symbolic links are now preserved as symlinks rather than dereferenced during directory replication, maintaining their integrity within copied directories. This ensures better consistency when copying complex directory structures containing symbolic references and improves overall file system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->