### PR TITLE
fix: display folder name instead of branch name in remove command

### DIFF
--- a/bin/gtr
+++ b/bin/gtr
@@ -349,7 +349,7 @@ cmd_remove() {
       continue
     fi
 
-    log_step "Removing worktree: $branch_name"
+    log_step "Removing worktree: $(basename "$worktree_path")"
 
     # Run pre-remove hooks (abort on failure unless --force)
     if ! run_hooks_in preRemove "$worktree_path" \


### PR DESCRIPTION
# Pull Request

## Description

Fix the remove command to display the folder name instead of the current branch name in the log message, making it consistent with the create command.

## Motivation

The remove command was displaying the current branch name (`$branch_name`) instead of the folder name being removed. This was confusing when:
- Branch names contain slashes (`feature/auth` → folder `feature-auth`)
- A different branch was checked out in the worktree
- Custom `--name` suffix was used during creation

Since `git gtr rm` removes a folder (worktree), the log message should show what is actually being removed.

Fixes #52

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

### Manual Testing Checklist

**Tested on:**

- [x] macOS
- [ ] Linux (specify distro: _______)
- [ ] Windows (Git Bash)

**Core functionality tested:**

- [x] `git gtr new <branch>` - Create worktree
- [ ] `git gtr go <branch>` - Navigate to worktree
- [ ] `git gtr editor <branch>` - Open in editor (if applicable)
- [ ] `git gtr ai <branch>` - Start AI tool (if applicable)
- [x] `git gtr rm <branch>` - Remove worktree
- [ ] `git gtr list` - List worktrees
- [ ] `git gtr config` - Configuration commands (if applicable)
- [ ] Other commands affected by this change: N/A

### Test Steps

1. Create worktree with slashes: `git gtr new feature/test`
2. Remove worktree: `git gtr rm feature/test`
3. Verify output shows folder name: `==> Removing worktree: feature-test`

**Expected behavior:** Log message shows folder name being removed.

**Actual behavior:** Log message now correctly shows folder name.

**Additional tests:**
- Created worktree, checked out different branch, removed by folder name - shows folder name (verified)
- Created worktree with `--name` suffix - shows full folder name (verified)

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] I have discussed this in an issue first
- [ ] Migration guide is included in documentation

## Checklist

Before submitting this PR, please check:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed manual testing on at least one platform
- [ ] I have updated documentation (README.md, CLAUDE.md, etc.) if needed
- [x] My changes work on multiple platforms (or I've noted platform-specific behavior)
- [ ] I have added/updated shell completions (if adding new commands or flags)
- [x] I have tested with both `git gtr` (production) and `./bin/gtr` (development)
- [x] No new external dependencies are introduced (Bash + git only)
- [x] All existing functionality still works

## Additional Context

The fix uses `$(basename "$worktree_path")` which follows existing codebase conventions (e.g., line 858 uses the same inline pattern for log messages).

---

## License Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache License 2.0](../LICENSE.txt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging clarity in the worktree removal process to display the worktree path instead of branch name for better identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->