### PR TITLE
fix: surface Git error message on worktree removal failure

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -423,11 +423,16 @@ remove_worktree() {
     force_flag="--force"
   fi
 
-  if git worktree remove $force_flag "$worktree_path" 2>/dev/null; then
+  local remove_output
+  if remove_output=$(git worktree remove $force_flag "$worktree_path" 2>&1); then
     log_info "Worktree removed: $worktree_path"
     return 0
   else
-    log_error "Failed to remove worktree"
+    if [ -n "$remove_output" ]; then
+      log_error "Failed to remove worktree: $remove_output"
+    else
+      log_error "Failed to remove worktree"
+    fi
     return 1
   fi
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when worktree removal operations fail, providing better diagnostic information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->