### PR TITLE
fix: rename gtr.fish to git-gtr.fish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,7 +403,7 @@ When adding new commands or flags, update all three completion files:
 
 - `completions/gtr.bash` (Bash)
 - `completions/_git-gtr` (Zsh)
-- `completions/gtr.fish` (Fish)
+- `completions/git-gtr.fish` (Fish)
 
 ### Git Version Compatibility
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ source ~/.zshrc
 **Fish:**
 
 ```bash
-ln -s /path/to/git-worktree-runner/completions/gtr.fish ~/.config/fish/completions/
+ln -s /path/to/git-worktree-runner/completions/git-gtr.fish ~/.config/fish/completions/
 ```
 
 ## Commands

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -5,7 +5,7 @@
 #
 # Installation:
 #   Symlink to fish's completions directory:
-#     ln -s /path/to/git-worktree-runner/completions/gtr.fish ~/.config/fish/completions/
+#     ln -s /path/to/git-worktree-runner/completions/git-gtr.fish ~/.config/fish/completions/
 #   Then reload fish:
 #     exec fish
 


### PR DESCRIPTION
fish autocompletion didn't work because installed binary name is `git-gtr`, not `gtr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guides and documentation to reference the renamed Fish shell completion file (now git-gtr.fish) so setup instructions point to the correct completion name.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->