### PR TITLE
docs: document how to remove all merged worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,22 +263,22 @@ git gtr config list                                # List all gtr config
 
 ### `git gtr clean [options]`
 
-Remove stale worktrees or worktrees with merged PRs.
+Remove worktrees: clean up empty directories, or remove those with merged GitHub PRs.
 
 ```bash
-git gtr clean                                  # Remove empty directories and prune
-git gtr clean --merged                         # Remove worktrees with merged PRs
-git gtr clean --merged --dry-run               # Preview what would be removed
-git gtr clean --merged --yes                   # Non-interactive mode
+git gtr clean                                  # Remove empty worktree directories and prune
+git gtr clean --merged                         # Remove worktrees for merged PRs (GitHub CLI required)
+git gtr clean --merged --dry-run               # Preview which worktrees would be removed
+git gtr clean --merged --yes                   # Remove without confirmation prompts
 ```
 
 **Options:**
 
-- `--merged`: Remove worktrees whose PRs are merged on GitHub
+- `--merged`: Remove worktrees whose branches have merged PRs on GitHub (also deletes the branch)
 - `--dry-run`, `-n`: Preview changes without removing
 - `--yes`, `-y`: Non-interactive mode (skip confirmation prompts)
 
-**Note:** The `--merged` mode requires the GitHub CLI (`gh`) to be installed and authenticated. It checks GitHub PRs to identify merged branches and removes their worktrees (and deletes the branches locally).
+**Note:** The `--merged` mode requires the GitHub CLI (`gh`) to be installed and authenticated. It checks GitHub PRs (e.g., PRs merged into the default branch `main`) using the GitHub CLI to inspect merge state and removes their worktrees (and deletes the branches locally).
 
 ### Other Commands
 


### PR DESCRIPTION
Fixes https://github.com/coderabbitai/git-worktree-runner/issues/75

`git gtr clean` is a popular command but docs was a bit lacking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for a new git gtr clean subcommand to remove stale worktrees and worktrees for merged pull requests
  * Described options: --merged (requires GitHub CLI), --dry-run/-n for preview, and --yes/-y for non-interactive use
  * Included practical usage examples and notes about authentication and merged-PR detection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->