### PR TITLE
fix(config): add file_key auto-mapping to cfg_default

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -406,6 +406,11 @@ cfg_default() {
   local file_key="${4:-}"
   local value
 
+  # Auto-map file_key if not provided and key is a gtr.* key
+  if [ -z "$file_key" ] && [[ "$key" == gtr.* ]]; then
+    file_key=$(cfg_map_to_file_key "$key")
+  fi
+
   # 1. Try local git config first (highest priority)
   value=$(git config --local --get "$key" 2>/dev/null || true)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in configuration key mapping for `gtr.*` prefixed keys, ensuring they are properly resolved when used in configuration lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->