### PR TITLE
feat(new): add --no-hooks flag to skip post-create hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,12 +186,12 @@ git config gtr.hook.preRemove "exit 1"
 ./bin/gtr rm test-hook-fail --force
 # Expected: Removal proceeds despite hook failure
 
-# Test --no-verify flag
+# Test --no-hooks flag
 git config --add gtr.hook.postCreate "echo 'Created!' > /tmp/gtr-test"
-./bin/gtr new test-no-verify --no-verify
+./bin/gtr new test-no-hooks --no-hooks
 # Expected: /tmp/gtr-test should NOT be created
 ls /tmp/gtr-test 2>&1  # Should fail
-./bin/gtr rm test-no-verify
+./bin/gtr rm test-no-hooks
 git config --unset gtr.hook.postCreate
 ```
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ git gtr new my-feature --name descriptive-variant                               
 - `--track <mode>`: Tracking mode (auto|remote|local|none)
 - `--no-copy`: Skip file copying
 - `--no-fetch`: Skip git fetch
-- `--no-verify`: Skip post-create hooks
+- `--no-hooks`: Skip post-create hooks
 - `--force`: Allow same branch in multiple worktrees (**requires --name or --folder**)
 - `--name <suffix>`: Custom folder name suffix (optional, required with --force)
 - `--folder <name>`: Custom folder name (replaces default, useful for long branch names)

--- a/bin/gtr
+++ b/bin/gtr
@@ -161,7 +161,7 @@ cmd_create() {
         skip_fetch=1
         shift
         ;;
-      --no-verify)
+      --no-hooks)
         skip_hooks=1
         shift
         ;;
@@ -318,7 +318,7 @@ cmd_create() {
     fi
   fi
 
-  # Run post-create hooks (unless --no-verify)
+  # Run post-create hooks (unless --no-hooks)
   if [ "$skip_hooks" -eq 0 ]; then
     run_hooks_in postCreate "$worktree_path" \
       REPO_ROOT="$repo_root" \
@@ -1555,7 +1555,7 @@ CORE COMMANDS (daily workflow):
          --track <mode>: tracking mode (auto|remote|local|none)
          --no-copy: skip file copying
          --no-fetch: skip git fetch
-         --no-verify: skip post-create hooks
+         --no-hooks: skip post-create hooks
          --force: allow same branch in multiple worktrees (requires --name or --folder)
          --name <suffix>: custom folder name suffix (e.g., backend, frontend)
          --folder <name>: custom folder name (replaces default, useful for long branches)

--- a/completions/_git-gtr
+++ b/completions/_git-gtr
@@ -59,7 +59,7 @@ _git-gtr() {
       '--track[Track mode]:mode:(auto remote local none)' \
       '--no-copy[Skip file copying]' \
       '--no-fetch[Skip git fetch]' \
-      '--no-verify[Skip post-create hooks]' \
+      '--no-hooks[Skip post-create hooks]' \
       '--force[Allow same branch in multiple worktrees]' \
       '--name[Custom folder name suffix]:name:' \
       '--folder[Custom folder name (replaces default)]:folder:' \

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -55,7 +55,7 @@ complete -c git -n '__fish_git_gtr_using_command new' -l from-current -d 'Create
 complete -c git -n '__fish_git_gtr_using_command new' -l track -d 'Track mode' -r -a 'auto remote local none'
 complete -c git -n '__fish_git_gtr_using_command new' -l no-copy -d 'Skip file copying'
 complete -c git -n '__fish_git_gtr_using_command new' -l no-fetch -d 'Skip git fetch'
-complete -c git -n '__fish_git_gtr_using_command new' -l no-verify -d 'Skip post-create hooks'
+complete -c git -n '__fish_git_gtr_using_command new' -l no-hooks -d 'Skip post-create hooks'
 complete -c git -n '__fish_git_gtr_using_command new' -l force -d 'Allow same branch in multiple worktrees'
 complete -c git -n '__fish_git_gtr_using_command new' -l name -d 'Custom folder name suffix' -r
 complete -c git -n '__fish_git_gtr_using_command new' -l folder -d 'Custom folder name (replaces default)' -r

--- a/completions/gtr.bash
+++ b/completions/gtr.bash
@@ -59,7 +59,7 @@ _git_gtr() {
     new)
       # Complete flags
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "--id --from --from-current --track --no-copy --no-fetch --no-verify --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
+        COMPREPLY=($(compgen -W "--id --from --from-current --track --no-copy --no-fetch --no-hooks --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
       elif [ "$prev" = "--track" ]; then
         COMPREPLY=($(compgen -W "auto remote local none" -- "$cur"))
       fi

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -126,7 +126,7 @@ git gtr rm ci-test --yes --delete-branch
 | `--yes`           | Skip all confirmation prompts        |
 | `--no-copy`       | Skip file copying (faster)           |
 | `--no-fetch`      | Skip git fetch (use existing refs)   |
-| `--no-verify`     | Skip post-create hooks               |
+| `--no-hooks`      | Skip post-create hooks               |
 | `--delete-branch` | Delete branch when removing worktree |
 
 ---


### PR DESCRIPTION
## Description

Add a `--no-verify` flag to `git gtr new` command that skips execution of post-create hooks.

I chose `--no-verify` over `--no-hooks` for consistency with git's convention (`git commit --no-verify`, `git push --no-verify`). However, I'm open to changing this to `--no-hooks` if preferred.

## Motivation

Fixes #90

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

### Manual Testing Checklist

**Tested on:**

- [ ] macOS
- [x] Linux (specify distro: **Debian**)
- [ ] Windows (Git Bash)

**Core functionality tested:**

Test report: https://github.com/lucasrcezimbra/git-worktree-runner/blob/be59e39ffdac88549b66014d7a59a3ebbbb1de59/test-report.md

- [x] `git gtr new <branch>` - Create worktree
- [ ] `git gtr go <branch>` - Navigate to worktree
- [ ] `git gtr editor <branch>` - Open in editor (if applicable)
- [ ] `git gtr ai <branch>` - Start AI tool (if applicable)
- [x] `git gtr rm <branch>` - Remove worktree
- [ ] `git gtr list` - List worktrees
- [ ] `git gtr config` - Configuration commands (if applicable)
- [x] Other commands affected by this change: **`git gtr new --no-verify`**

### Test Steps

1. Configure a post-create hook:
   ```bash
   git config --add gtr.hook.postCreate "echo 'Created!' > /tmp/gtr-test"
   ```
2. Create worktree without the flag:
   ```bash
   ./bin/gtr new test-with-hooks
   cat /tmp/gtr-test  # Should show "Created!"
   rm /tmp/gtr-test
   ```
3. Create worktree with `--no-verify`:
   ```bash
   ./bin/gtr new test-no-verify --no-verify
   ls /tmp/gtr-test  # Should fail - file should NOT exist
   ```
4. Cleanup:
   ```bash
   ./bin/gtr rm test-with-hooks
   ./bin/gtr rm test-no-verify
   git config --unset gtr.hook.postCreate
   ```

**Expected behavior:** When `--no-verify` is passed, post-create hooks should be skipped.

**Actual behavior:** Works as expected. Hooks run normally without the flag, and are skipped with `--no-verify`.

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] I have discussed this in an issue first
- [ ] Migration guide is included in documentation

## Checklist

Before submitting this PR, please check:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed manual testing on at least one platform
- [x] I have updated documentation (README.md, CLAUDE.md, etc.) if needed
- [x] My changes work on multiple platforms (or I've noted platform-specific behavior)
- [x] I have added/updated shell completions (if adding new commands or flags)
- [x] I have tested with both `git gtr` (production) and `./bin/gtr` (development)
- [x] No new external dependencies are introduced (Bash + git only)
- [x] All existing functionality still works

---

## License Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache License 2.0](../LICENSE.txt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added --no-hooks flag to the git gtr new command to skip post-create hooks during worktree creation.

* **Documentation**
  * Updated CLI docs and help text; added shell completion support for Bash, Fish, and Zsh.

* **Tests**
  * Added a test scenario demonstrating the --no-hooks behavior and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->