### PR TITLE
feat: add mv command to rename worktree branch and folder 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,20 @@ cd "$(./bin/gtr go test-feature)"
 ./bin/gtr run test-feature echo "Hello from worktree"
 # Expected: Outputs "Hello from worktree"
 
+# Test mv/rename command
+./bin/gtr new test-old
+./bin/gtr mv test-old test-new
+./bin/gtr list
+# Expected: Shows test-new, not test-old
+./bin/gtr mv 1 something
+# Expected: Error "Cannot rename main repository"
+./bin/gtr new test-conflict
+./bin/gtr mv test-new test-conflict
+# Expected: Error "Branch 'test-conflict' already exists"
+./bin/gtr mv test-new test-renamed --yes
+# Expected: Renames without confirmation prompt
+./bin/gtr rm test-renamed test-conflict
+
 # Test copy patterns with include/exclude
 git config --add gtr.copy.include "**/.env.example"
 git config --add gtr.copy.exclude "**/.env"

--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ git gtr rm my-feature --delete-branch --force      # Delete branch and force
 
 **Options:** `--delete-branch`, `--force`, `--yes`
 
+### `git gtr mv <branch> <new-name> [options]`
+
+Rename a worktree's branch and folder in one operation.
+
+```bash
+git gtr mv feature-wip feature-auth           # Rename branch + folder
+git gtr mv feature-wip feature-auth --yes     # Skip confirmation
+git gtr mv feature-wip feature-auth --force   # Force if dirty/locked
+```
+
+**Options:** `--force`, `--yes`
+**Alias:** `rename`
+
 ### `git gtr copy <target>... [options] [-- <pattern>...]`
 
 Copy files from main repo to existing worktree(s). Useful for syncing env files after worktree creation.

--- a/bin/gtr
+++ b/bin/gtr
@@ -90,6 +90,9 @@ main() {
     copy)
       cmd_copy "$@"
       ;;
+    mv|rename)
+      cmd_move "$@"
+      ;;
     ls|list)
       cmd_list "$@"
       ;;
@@ -488,6 +491,115 @@ cmd_remove() {
       WORKTREE_PATH="$worktree_path" \
       BRANCH="$branch_name"
   done
+}
+
+# Move/rename command
+cmd_move() {
+  local old_id=""
+  local new_name=""
+  local force=0
+  local yes_mode=0
+
+  # Parse flags and arguments
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --force)
+        force=1
+        shift
+        ;;
+      --yes)
+        yes_mode=1
+        shift
+        ;;
+      -*)
+        log_error "Unknown flag: $1"
+        exit 1
+        ;;
+      *)
+        if [ -z "$old_id" ]; then
+          old_id="$1"
+        elif [ -z "$new_name" ]; then
+          new_name="$1"
+        fi
+        shift
+        ;;
+    esac
+  done
+
+  if [ -z "$old_id" ] || [ -z "$new_name" ]; then
+    log_error "Usage: git gtr mv <branch> <new-name> [--force] [--yes]"
+    exit 1
+  fi
+
+  local repo_root base_dir prefix
+  repo_root=$(discover_repo_root) || exit 1
+  base_dir=$(resolve_base_dir "$repo_root")
+  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+
+  # Resolve old worktree
+  local target is_main old_path old_branch
+  target=$(resolve_target "$old_id" "$repo_root" "$base_dir" "$prefix") || exit 1
+  is_main=$(echo "$target" | cut -f1)
+  old_path=$(echo "$target" | cut -f2)
+  old_branch=$(echo "$target" | cut -f3)
+
+  # Cannot rename main repository
+  if [ "$is_main" = "1" ]; then
+    log_error "Cannot rename main repository"
+    exit 1
+  fi
+
+  # Check if new branch name already exists
+  if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$new_name" 2>/dev/null; then
+    log_error "Branch '$new_name' already exists"
+    exit 1
+  fi
+
+  # Compute new worktree path
+  local new_folder
+  new_folder="${prefix}$(sanitize_branch_name "$new_name")"
+  local new_path="$base_dir/$new_folder"
+
+  # Check if target path already exists
+  if [ -d "$new_path" ]; then
+    log_error "Directory already exists: $new_path"
+    exit 1
+  fi
+
+  log_step "Renaming worktree"
+  echo "Branch: $old_branch → $new_name"
+  echo "Folder: $(basename "$old_path") → $new_folder"
+
+  # Confirm unless --yes
+  if [ "$yes_mode" -eq 0 ]; then
+    if ! prompt_yes_no "Proceed with rename?"; then
+      log_info "Cancelled"
+      exit 0
+    fi
+  fi
+
+  # Rename branch
+  if ! git -C "$repo_root" branch -m "$old_branch" "$new_name"; then
+    log_error "Failed to rename branch"
+    exit 1
+  fi
+
+  # Move worktree
+  local move_args=()
+  if [ "$force" -eq 1 ]; then
+    move_args+=(--force)
+  fi
+  if ! git -C "$repo_root" worktree move "$old_path" "$new_path" "${move_args[@]}"; then
+    # Rollback branch rename
+    log_warn "Worktree move failed, rolling back branch rename..."
+    git -C "$repo_root" branch -m "$new_name" "$old_branch" 2>/dev/null
+    log_error "Failed to move worktree"
+    exit 1
+  fi
+
+  echo ""
+  log_info "Renamed: $old_branch → $new_name"
+  log_info "Location: $new_path"
 }
 
 # Go command (navigate to worktree - prints path for shell integration)
@@ -1593,6 +1705,12 @@ CORE COMMANDS (daily workflow):
          --delete-branch: also delete the branch
          --force: force removal (dirty worktree)
          --yes: skip confirmation
+
+  mv <branch> <new-name> [options]
+         Rename worktree branch and folder
+         --force: force move (dirty/locked worktree)
+         --yes: skip confirmation
+         Alias: rename
 
   copy <target>... [options] [-- <pattern>...]
          Copy files from main repo to worktree(s)

--- a/completions/_git-gtr
+++ b/completions/_git-gtr
@@ -31,6 +31,8 @@ _git-gtr() {
     'run:Execute command in worktree'
     'copy:Copy files between worktrees'
     'rm:Remove worktree(s)'
+    'mv:Rename worktree branch and folder'
+    'rename:Rename worktree branch and folder'
     'editor:Open worktree in editor'
     'ai:Start AI coding tool'
     'ls:List all worktrees'
@@ -83,7 +85,7 @@ _git-gtr() {
   # Complete arguments to the subcommand
   elif (( CURRENT == 4 )); then
     case "$words[3]" in
-      go|run|rm|copy)
+      go|run|rm|mv|rename|copy)
         _describe 'branch names' all_options
         ;;
       editor)
@@ -115,6 +117,11 @@ _git-gtr() {
           '--delete-branch[Delete branch]' \
           '--force[Force removal even if dirty]' \
           '--yes[Non-interactive mode]'
+        ;;
+      mv|rename)
+        _arguments \
+          '--force[Force move even if dirty/locked]' \
+          '--yes[Skip confirmation]'
         ;;
       copy)
         _arguments \

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -35,6 +35,8 @@ complete -f -c git -n '__fish_git_gtr_needs_command' -a new -d 'Create a new wor
 complete -f -c git -n '__fish_git_gtr_needs_command' -a go -d 'Navigate to worktree'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a run -d 'Execute command in worktree'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a rm -d 'Remove worktree(s)'
+complete -f -c git -n '__fish_git_gtr_needs_command' -a mv -d 'Rename worktree branch and folder'
+complete -f -c git -n '__fish_git_gtr_needs_command' -a rename -d 'Rename worktree branch and folder'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a copy -d 'Copy files between worktrees'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a editor -d 'Open worktree in editor'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a ai -d 'Start AI coding tool'
@@ -67,6 +69,11 @@ complete -c git -n '__fish_git_gtr_using_command new' -s a -l ai -d 'Start AI to
 complete -c git -n '__fish_git_gtr_using_command rm' -l delete-branch -d 'Delete branch'
 complete -c git -n '__fish_git_gtr_using_command rm' -l force -d 'Force removal even if dirty'
 complete -c git -n '__fish_git_gtr_using_command rm' -l yes -d 'Non-interactive mode'
+
+# Move/rename command options
+complete -c git -n '__fish_git_gtr_using_command mv rename' -l force -d 'Force move even if dirty/locked'
+complete -c git -n '__fish_git_gtr_using_command mv rename' -l yes -d 'Skip confirmation'
+complete -f -c git -n '__fish_git_gtr_using_command mv rename' -a '(__gtr_worktree_branches)'
 
 # Copy command options
 complete -c git -n '__fish_git_gtr_using_command copy' -s n -l dry-run -d 'Preview without copying'

--- a/completions/gtr.bash
+++ b/completions/gtr.bash
@@ -22,7 +22,7 @@ _git_gtr() {
 
   # If we're completing the first argument after 'git gtr'
   if [ "$cword" -eq 2 ]; then
-    COMPREPLY=($(compgen -W "new go run copy editor ai rm ls list clean doctor adapter config completion help version" -- "$cur"))
+    COMPREPLY=($(compgen -W "new go run copy editor ai rm mv rename ls list clean doctor adapter config completion help version" -- "$cur"))
     return 0
   fi
 
@@ -30,7 +30,7 @@ _git_gtr() {
 
   # Commands that take branch names or '1' for main repo
   case "$cmd" in
-    go|run|editor|ai|rm)
+    go|run|editor|ai|rm|mv|rename)
       if [ "$cword" -eq 3 ]; then
         # Complete with branch names and special ID '1' for main repo
         local branches all_options
@@ -41,6 +41,9 @@ _git_gtr() {
         case "$cmd" in
           rm)
             COMPREPLY=($(compgen -W "--delete-branch --force --yes" -- "$cur"))
+            ;;
+          mv|rename)
+            COMPREPLY=($(compgen -W "--force --yes" -- "$cur"))
             ;;
         esac
       fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `git gtr mv` command (alias `rename`) to simultaneously rename a worktree's branch and folder, with `--force` and `--yes` options for safe operations.

* **Documentation**
  * Added command reference and test documentation for the new move/rename functionality.

* **Chores**
  * Updated shell completions for new command support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->