### PR TITLE
refactor: deduplicate glob expansion, add excludes to symlinks

### DIFF
--- a/bin/gtr
+++ b/bin/gtr
@@ -136,6 +136,7 @@ cmd_create() {
   local from_current=0
   local track_mode="auto"
   local skip_copy=0
+  local skip_symlink=0
   local skip_fetch=0
   local skip_hooks=0
   local yes_mode=0
@@ -162,6 +163,11 @@ cmd_create() {
         ;;
       --no-copy)
         skip_copy=1
+        skip_symlink=1
+        shift
+        ;;
+      --no-symlink)
+        skip_symlink=1
         shift
         ;;
       --no-fetch)
@@ -322,6 +328,23 @@ cmd_create() {
     if [ -n "$dir_includes" ]; then
       log_step "Copying directories..."
       copy_directories "$repo_root" "$worktree_path" "$dir_includes" "$dir_excludes"
+    fi
+  fi
+
+  # Create symlinks
+  if [ "$skip_symlink" -eq 0 ]; then
+    local sym_includes sym_dir_includes sym_excludes
+    sym_includes=$(cfg_get_all gtr.symlink.include symlink.include)
+    sym_dir_includes=$(cfg_get_all gtr.symlink.includeDirs symlink.includeDirs)
+    sym_excludes=$(cfg_get_all gtr.copy.exclude copy.exclude)
+
+    if [ -n "$sym_includes" ]; then
+      log_step "Creating file symlinks..."
+      symlink_patterns "$repo_root" "$worktree_path" "$sym_includes" "$sym_excludes"
+    fi
+    if [ -n "$sym_dir_includes" ]; then
+      log_step "Creating directory symlinks..."
+      symlink_directories "$repo_root" "$worktree_path" "$sym_dir_includes"
     fi
   fi
 
@@ -716,6 +739,7 @@ cmd_copy() {
   local patterns=""
   local all_mode=0
   local dry_run=0
+  local symlink_mode=0
 
   # Parse arguments (patterns come after -- separator, like git pathspec)
   while [ $# -gt 0 ]; do
@@ -730,6 +754,10 @@ cmd_copy() {
         ;;
       -a|--all)
         all_mode=1
+        shift
+        ;;
+      -s|--symlink)
+        symlink_mode=1
         shift
         ;;
       --)
@@ -758,7 +786,7 @@ cmd_copy() {
 
   # Validation
   if [ "$all_mode" -eq 0 ] && [ -z "$targets" ]; then
-    log_error "Usage: git gtr copy <target>... [-n] [-a] [--from <source>] [-- <pattern>...]"
+    log_error "Usage: git gtr copy <target>... [-n] [-a] [-s] [--from <source>] [-- <pattern>...]"
     exit 1
   fi
 
@@ -773,30 +801,46 @@ cmd_copy() {
   src_target=$(resolve_target "$source" "$repo_root" "$base_dir" "$prefix") || exit 1
   src_path=$(echo "$src_target" | cut -f2)
 
-  # Get patterns (flag > config)
-  if [ -z "$patterns" ]; then
-    patterns=$(cfg_get_all gtr.copy.include copy.include)
-    # Also check .worktreeinclude
-    if [ -f "$repo_root/.worktreeinclude" ]; then
-      local file_patterns
-      file_patterns=$(parse_pattern_file "$repo_root/.worktreeinclude")
-      if [ -n "$file_patterns" ]; then
-        if [ -n "$patterns" ]; then
-          patterns="$patterns"$'\n'"$file_patterns"
-        else
-          patterns="$file_patterns"
+  # Resolve includes, excludes, and dir_includes based on mode
+  local includes="" excludes="" dir_includes=""
+  excludes=$(cfg_get_all gtr.copy.exclude copy.exclude)
+
+  if [ "$symlink_mode" -eq 1 ]; then
+    if [ -n "$patterns" ]; then
+      includes="$patterns"
+    else
+      includes=$(cfg_get_all gtr.symlink.include symlink.include)
+      dir_includes=$(cfg_get_all gtr.symlink.includeDirs symlink.includeDirs)
+    fi
+
+    if [ -z "$includes" ] && [ -z "$dir_includes" ]; then
+      log_error "No symlink patterns configured. Use '-- <pattern>...' or configure gtr.symlink.include"
+      exit 1
+    fi
+  else
+    if [ -n "$patterns" ]; then
+      includes="$patterns"
+    else
+      includes=$(cfg_get_all gtr.copy.include copy.include)
+      # Also check .worktreeinclude
+      if [ -f "$repo_root/.worktreeinclude" ]; then
+        local file_patterns
+        file_patterns=$(parse_pattern_file "$repo_root/.worktreeinclude")
+        if [ -n "$file_patterns" ]; then
+          if [ -n "$includes" ]; then
+            includes="$includes"$'\n'"$file_patterns"
+          else
+            includes="$file_patterns"
+          fi
         fi
       fi
     fi
-  fi
 
-  if [ -z "$patterns" ]; then
-    log_error "No patterns specified. Use '-- <pattern>...' or configure gtr.copy.include"
-    exit 1
+    if [ -z "$includes" ]; then
+      log_error "No patterns specified. Use '-- <pattern>...' or configure gtr.copy.include"
+      exit 1
+    fi
   fi
-
-  local excludes
-  excludes=$(cfg_get_all gtr.copy.exclude copy.exclude)
 
   # Build target list for --all mode
   if [ "$all_mode" -eq 1 ]; then
@@ -808,28 +852,48 @@ cmd_copy() {
   fi
 
   # Process each target
-  local copied_any=0
+  local processed_any=0
   for target_id in $targets; do
     local dst_target dst_path dst_branch
     dst_target=$(resolve_target "$target_id" "$repo_root" "$base_dir" "$prefix") || continue
     dst_path=$(echo "$dst_target" | cut -f2)
     dst_branch=$(echo "$dst_target" | cut -f3)
 
-    # Skip if source == destination
     [ "$src_path" = "$dst_path" ] && continue
 
-    if [ "$dry_run" -eq 1 ]; then
-      log_step "[dry-run] Would copy to: $dst_branch"
-      copy_patterns "$src_path" "$dst_path" "$patterns" "$excludes" "true" "true"
+    local dry_arg=""
+    [ "$dry_run" -eq 1 ] && dry_arg="true"
+
+    if [ "$symlink_mode" -eq 1 ]; then
+      if [ "$dry_run" -eq 1 ]; then
+        log_step "[dry-run] Would symlink to: $dst_branch"
+      else
+        log_step "Symlinking to: $dst_branch"
+      fi
+      if [ -n "$includes" ]; then
+        symlink_patterns "$src_path" "$dst_path" "$includes" "$excludes" "$dry_arg"
+      fi
+      if [ -n "$dir_includes" ]; then
+        symlink_directories "$src_path" "$dst_path" "$dir_includes" "$dry_arg"
+      fi
     else
-      log_step "Copying to: $dst_branch"
-      copy_patterns "$src_path" "$dst_path" "$patterns" "$excludes" "true"
+      if [ "$dry_run" -eq 1 ]; then
+        log_step "[dry-run] Would copy to: $dst_branch"
+        copy_patterns "$src_path" "$dst_path" "$includes" "$excludes" "true" "true"
+      else
+        log_step "Copying to: $dst_branch"
+        copy_patterns "$src_path" "$dst_path" "$includes" "$excludes" "true"
+      fi
     fi
-    copied_any=1
+    processed_any=1
   done
 
-  if [ "$copied_any" -eq 0 ]; then
-    log_warn "No files copied (source and target may be the same)"
+  if [ "$processed_any" -eq 0 ]; then
+    if [ "$symlink_mode" -eq 1 ]; then
+      log_warn "No symlinks created (source and target may be the same)"
+    else
+      log_warn "No files copied (source and target may be the same)"
+    fi
   fi
 }
 
@@ -1305,6 +1369,21 @@ cmd_doctor() {
   local os
   os=$(detect_os)
   echo "[OK] Platform: $os"
+
+  # Check symlink support (relevant on Windows/MSYS2)
+  if [ "$os" = "windows" ]; then
+    local test_link="/tmp/.gtr-symlink-test-$$"
+    local test_target="/tmp/.gtr-symlink-target-$$"
+    touch "$test_target" 2>/dev/null
+    if ln -s "$test_target" "$test_link" 2>/dev/null; then
+      echo "[OK] Symlinks: supported"
+      rm -f "$test_link" "$test_target" 2>/dev/null
+    else
+      echo "[!] Symlinks: not available (enable Developer Mode or run as admin)"
+      issues=$((issues + 1))
+      rm -f "$test_target" 2>/dev/null
+    fi
+  fi
 
   # Check hosting provider
   if [ -n "$repo_root" ]; then
@@ -1815,7 +1894,8 @@ CORE COMMANDS (daily workflow):
          --from <ref>: create from specific ref
          --from-current: create from current branch (for parallel variants)
          --track <mode>: tracking mode (auto|remote|local|none)
-         --no-copy: skip file copying
+         --no-copy: skip file copying and symlinking
+         --no-symlink: skip symlink creation (keeps file copying)
          --no-fetch: skip git fetch
          --no-hooks: skip post-create hooks
          --force: allow same branch in multiple worktrees (requires --name or --folder)
@@ -1871,8 +1951,9 @@ CORE COMMANDS (daily workflow):
          Copy files from main repo to worktree(s)
          -n, --dry-run: preview without copying
          -a, --all: copy to all worktrees
+         -s, --symlink: create symlinks instead of copying (uses gtr.symlink.* config)
          --from <source>: copy from different worktree (default: main repo)
-         Patterns after -- override gtr.copy.include config
+         Patterns after -- override gtr.copy.include (or gtr.symlink.include with -s)
 
          Examples:
            git gtr copy my-feature                       # Uses configured patterns
@@ -1880,6 +1961,8 @@ CORE COMMANDS (daily workflow):
            git gtr copy my-feature -- ".env*" "*.json"   # Multiple patterns
            git gtr copy -a -- ".env*"                    # Update all worktrees
            git gtr copy my-feature -n -- "**/.env*"      # Dry-run preview
+           git gtr copy my-feature --symlink             # Create/refresh symlinks
+           git gtr copy -a --symlink --dry-run           # Preview symlinks for all
 
 ────────────────────────────────────────────────────────────────────────────────
 
@@ -1949,6 +2032,11 @@ WORKFLOW EXAMPLES:
   git gtr editor feature/user-auth --editor vscode
   git gtr ai feature/user-auth --ai aider
 
+  # Keep settings in sync across worktrees (symlinks)
+  git gtr config add gtr.symlink.includeDirs .claude
+  git gtr new my-feature                          # .claude/ symlinked automatically
+  git gtr copy my-feature --symlink               # Refresh symlinks on existing worktree
+
   # Chain commands together
   git gtr new hotfix && git gtr editor hotfix && git gtr ai hotfix
 
@@ -1988,6 +2076,11 @@ CONFIGURATION OPTIONS:
                            Use gtr.copy.excludeDirs to exclude them.
   gtr.copy.excludeDirs     Directories to exclude (multi-valued)
                            Supports glob patterns (e.g., "node_modules/.cache", "*/.npm")
+  gtr.symlink.include      Files to symlink (multi-valued, glob patterns)
+                           Symlinks stay in sync — changes reflect everywhere
+                           Example: .claude/settings.json
+  gtr.symlink.includeDirs  Directories to symlink (multi-valued)
+                           Example: .claude, .bmad
   gtr.hook.postCreate      Post-create hooks (multi-valued)
   gtr.hook.preRemove       Pre-remove hooks (multi-valued, abort on failure)
   gtr.hook.postRemove      Post-remove hooks (multi-valued)

--- a/completions/_git-gtr
+++ b/completions/_git-gtr
@@ -60,7 +60,8 @@ _git-gtr() {
       '--from[Base ref]:ref:' \
       '--from-current[Create from current branch]' \
       '--track[Track mode]:mode:(auto remote local none)' \
-      '--no-copy[Skip file copying]' \
+      '--no-copy[Skip file copying and symlinking]' \
+      '--no-symlink[Skip symlink creation]' \
       '--no-fetch[Skip git fetch]' \
       '--no-hooks[Skip post-create hooks]' \
       '--force[Allow same branch in multiple worktrees]' \
@@ -141,6 +142,8 @@ _git-gtr() {
           '--dry-run[Preview without copying]' \
           '-a[Copy to all worktrees]' \
           '--all[Copy to all worktrees]' \
+          '-s[Create symlinks instead of copying]' \
+          '--symlink[Create symlinks instead of copying]' \
           '--from[Source worktree]:source:->worktrees' \
           '*:target:->worktrees'
         case "$state" in
@@ -172,7 +175,7 @@ _git-gtr() {
                 '--local[Use local git config]' \
                 '--global[Use global git config]' \
                 '--system[Use system git config]' \
-                '*:config key:(gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove)'
+                '*:config key:(gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.symlink.include gtr.symlink.includeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove)'
               ;;
             set|add|unset)
               # Write operations only support --local and --global
@@ -180,7 +183,7 @@ _git-gtr() {
               _arguments \
                 '--local[Use local git config]' \
                 '--global[Use global git config]' \
-                '*:config key:(gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove)'
+                '*:config key:(gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.symlink.include gtr.symlink.includeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove)'
               ;;
           esac
         fi

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -57,7 +57,8 @@ complete -f -c git -n '__fish_git_gtr_needs_command' -a help -d 'Show help'
 complete -c git -n '__fish_git_gtr_using_command new' -l from -d 'Base ref' -r
 complete -c git -n '__fish_git_gtr_using_command new' -l from-current -d 'Create from current branch'
 complete -c git -n '__fish_git_gtr_using_command new' -l track -d 'Track mode' -r -a 'auto remote local none'
-complete -c git -n '__fish_git_gtr_using_command new' -l no-copy -d 'Skip file copying'
+complete -c git -n '__fish_git_gtr_using_command new' -l no-copy -d 'Skip file copying and symlinking'
+complete -c git -n '__fish_git_gtr_using_command new' -l no-symlink -d 'Skip symlink creation'
 complete -c git -n '__fish_git_gtr_using_command new' -l no-fetch -d 'Skip git fetch'
 complete -c git -n '__fish_git_gtr_using_command new' -l no-hooks -d 'Skip post-create hooks'
 complete -c git -n '__fish_git_gtr_using_command new' -l force -d 'Allow same branch in multiple worktrees'
@@ -81,6 +82,7 @@ complete -c git -n '__fish_git_gtr_using_command rename' -l yes -d 'Skip confirm
 # Copy command options
 complete -c git -n '__fish_git_gtr_using_command copy' -s n -l dry-run -d 'Preview without copying'
 complete -c git -n '__fish_git_gtr_using_command copy' -s a -l all -d 'Copy to all worktrees'
+complete -c git -n '__fish_git_gtr_using_command copy' -s s -l symlink -d 'Create symlinks instead of copying'
 complete -c git -n '__fish_git_gtr_using_command copy' -l from -d 'Source worktree' -r
 
 # Clean command options
@@ -132,6 +134,8 @@ complete -f -c git -n '__fish_git_gtr_using_command config' -a "
   gtr.copy.exclude\t'Files to exclude'
   gtr.copy.includeDirs\t'Directories to copy (e.g., node_modules)'
   gtr.copy.excludeDirs\t'Directories to exclude'
+  gtr.symlink.include\t'Files to symlink (glob patterns)'
+  gtr.symlink.includeDirs\t'Directories to symlink'
   gtr.hook.postCreate\t'Post-create hook'
   gtr.hook.preRemove\t'Pre-remove hook (abort on failure)'
   gtr.hook.postRemove\t'Post-remove hook'

--- a/completions/gtr.bash
+++ b/completions/gtr.bash
@@ -55,7 +55,7 @@ _git_gtr() {
       ;;
     copy)
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "-n --dry-run -a --all --from" -- "$cur"))
+        COMPREPLY=($(compgen -W "-n --dry-run -a --all -s --symlink --from" -- "$cur"))
       else
         # Complete with branch names and special ID '1' for main repo
         local branches all_options
@@ -67,7 +67,7 @@ _git_gtr() {
     new)
       # Complete flags
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "--id --from --from-current --track --no-copy --no-fetch --no-hooks --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
+        COMPREPLY=($(compgen -W "--id --from --from-current --track --no-copy --no-symlink --no-fetch --no-hooks --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
       elif [ "$prev" = "--track" ]; then
         COMPREPLY=($(compgen -W "auto remote local none" -- "$cur"))
       fi
@@ -99,7 +99,7 @@ _git_gtr() {
             if [[ "$cur" == -* ]]; then
               COMPREPLY=($(compgen -W "--local --global --system" -- "$cur"))
             else
-              COMPREPLY=($(compgen -W "gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove" -- "$cur"))
+              COMPREPLY=($(compgen -W "gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.symlink.include gtr.symlink.includeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove" -- "$cur"))
             fi
             ;;
           set|add|unset)
@@ -107,7 +107,7 @@ _git_gtr() {
             if [[ "$cur" == -* ]]; then
               COMPREPLY=($(compgen -W "--local --global" -- "$cur"))
             else
-              COMPREPLY=($(compgen -W "gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove" -- "$cur"))
+              COMPREPLY=($(compgen -W "gtr.worktrees.dir gtr.worktrees.prefix gtr.defaultBranch gtr.editor.default gtr.ai.default gtr.provider gtr.copy.include gtr.copy.exclude gtr.copy.includeDirs gtr.copy.excludeDirs gtr.symlink.include gtr.symlink.includeDirs gtr.hook.postCreate gtr.hook.preRemove gtr.hook.postRemove" -- "$cur"))
             fi
             ;;
         esac

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -96,8 +96,10 @@ cfg_map_to_file_key() {
     gtr.worktrees.dir)    echo "worktrees.dir" ;;
     gtr.worktrees.prefix) echo "worktrees.prefix" ;;
     gtr.defaultBranch)    echo "defaults.branch" ;;
-    gtr.provider)         echo "defaults.provider" ;;
-    *)                    echo "" ;;
+    gtr.provider)           echo "defaults.provider" ;;
+    gtr.symlink.include)    echo "symlink.include" ;;
+    gtr.symlink.includeDirs) echo "symlink.includeDirs" ;;
+    *)                      echo "" ;;
   esac
 }
 
@@ -312,10 +314,12 @@ cfg_list() {
             defaults.ai)      mapped_key="gtr.ai.default" ;;
             defaults.branch)  mapped_key="gtr.defaultBranch" ;;
             defaults.provider) mapped_key="gtr.provider" ;;
-            worktrees.dir)    mapped_key="gtr.worktrees.dir" ;;
-            worktrees.prefix) mapped_key="gtr.worktrees.prefix" ;;
-            gtr.*)            mapped_key="$fkey" ;;
-            *)                continue ;;  # Skip unmapped keys
+            worktrees.dir)      mapped_key="gtr.worktrees.dir" ;;
+            worktrees.prefix)   mapped_key="gtr.worktrees.prefix" ;;
+            symlink.include)    mapped_key="gtr.symlink.include" ;;
+            symlink.includeDirs) mapped_key="gtr.symlink.includeDirs" ;;
+            gtr.*)              mapped_key="$fkey" ;;
+            *)                  continue ;;  # Skip unmapped keys
           esac
           _cfg_list_add_entry ".gtrconfig" "$mapped_key" "$fvalue"
         done < <(git config -f "$config_file" --get-regexp '.' 2>/dev/null || true)

--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -15,6 +15,102 @@ parse_pattern_file() {
   grep -v '^#' "$file_path" 2>/dev/null | grep -v '^[[:space:]]*$' || true
 }
 
+# Expand glob patterns against a source directory, filtering excludes.
+# Outputs matched file paths to stdout (one per line, relative to src_root).
+# Usage: _expand_file_patterns src_root includes [excludes]
+# Internal helper — callers iterate output and perform the file operation.
+_expand_file_patterns() {
+  local src_root="$1"
+  local includes="$2"
+  local excludes="${3:-}"
+
+  if [ -z "$includes" ]; then
+    return 0
+  fi
+
+  # Change to source directory
+  local old_pwd
+  old_pwd=$(pwd)
+  cd "$src_root" || return 1
+
+  # Save and configure shell options
+  local shopt_save
+  shopt_save="$(shopt -p nullglob dotglob globstar 2>/dev/null || true)"
+
+  local have_globstar=0
+  if shopt -s globstar 2>/dev/null; then
+    have_globstar=1
+  fi
+  shopt -s nullglob dotglob 2>/dev/null || true
+
+  # Process each include pattern
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+
+    # Security: reject absolute paths and parent directory traversal
+    case "$pattern" in
+      /*|*/../*|../*|*/..|..)
+        log_warn "Skipping unsafe pattern (absolute path or '..' path segment): $pattern"
+        continue
+        ;;
+    esac
+
+    # Collect matched files into a list, then filter
+    # Detect if pattern uses ** (requires globstar)
+    if [ "$have_globstar" -eq 0 ] && echo "$pattern" | grep -q '\*\*'; then
+      # Fallback to find for ** patterns on Bash 3.2
+      while IFS= read -r file; do
+        file="${file#./}"
+        # Check excludes and emit
+        local excluded=0
+        if [ -n "$excludes" ]; then
+          while IFS= read -r exclude_pattern; do
+            [ -z "$exclude_pattern" ] && continue
+            # shellcheck disable=SC2254
+            case "$file" in
+              $exclude_pattern) excluded=1; break ;;
+            esac
+          done <<EXCL
+$excludes
+EXCL
+        fi
+        [ "$excluded" -eq 0 ] && echo "$file"
+      done <<EOF
+$(find . -path "./$pattern" -type f 2>/dev/null)
+EOF
+    else
+      # Use native Bash glob expansion
+      for file in $pattern; do
+        [ -f "$file" ] || continue
+        file="${file#./}"
+        # Check excludes and emit
+        local excluded=0
+        if [ -n "$excludes" ]; then
+          while IFS= read -r exclude_pattern; do
+            [ -z "$exclude_pattern" ] && continue
+            # shellcheck disable=SC2254
+            case "$file" in
+              $exclude_pattern) excluded=1; break ;;
+            esac
+          done <<EXCL
+$excludes
+EXCL
+        fi
+        [ "$excluded" -eq 0 ] && echo "$file"
+      done
+    fi
+  done <<EOF
+$includes
+EOF
+
+  # Restore previous shell options
+  eval "$shopt_save" 2>/dev/null || true
+  cd "$old_pwd" || return 1
+
+  return 0
+}
+
+
 # Copy files matching patterns from source to destination
 # Usage: copy_patterns src_root dst_root includes excludes [preserve_paths] [dry_run]
 # includes: newline-separated glob patterns to include
@@ -30,164 +126,40 @@ copy_patterns() {
   local dry_run="${6:-false}"
 
   if [ -z "$includes" ]; then
-    # No patterns to copy
     return 0
   fi
 
-  # Change to source directory
-  local old_pwd
-  old_pwd=$(pwd)
-  cd "$src_root" || return 1
-
-  # Save current shell options
-  local shopt_save
-  shopt_save="$(shopt -p nullglob dotglob globstar 2>/dev/null || true)"
-
-  # Try to enable globstar for ** patterns (Bash 4.0+)
-  # nullglob: patterns that don't match expand to nothing
-  # dotglob: * matches hidden files
-  # globstar: ** matches directories recursively
-  local have_globstar=0
-  if shopt -s globstar 2>/dev/null; then
-    have_globstar=1
-  fi
-  shopt -s nullglob dotglob 2>/dev/null || true
-
   local copied_count=0
+  local file
 
-  # Process each include pattern (avoid pipeline subshell)
-  while IFS= read -r pattern; do
-    [ -z "$pattern" ] && continue
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
 
-    # Security: reject absolute paths and parent directory traversal
-    case "$pattern" in
-      /*|*/../*|../*|*/..|..)
-        log_warn "Skipping unsafe pattern (absolute path or '..' path segment): $pattern"
-        continue
-        ;;
-    esac
-
-    # Detect if pattern uses ** (requires globstar)
-    if [ "$have_globstar" -eq 0 ] && echo "$pattern" | grep -q '\*\*'; then
-      # Fallback to find for ** patterns on Bash 3.2
-      while IFS= read -r file; do
-        # Remove leading ./
-        file="${file#./}"
-
-        # Check if file matches any exclude pattern
-        local excluded=0
-        if [ -n "$excludes" ]; then
-          while IFS= read -r exclude_pattern; do
-            [ -z "$exclude_pattern" ] && continue
-            # Intentional glob pattern matching for file exclusion
-            # shellcheck disable=SC2254
-            case "$file" in
-              $exclude_pattern)
-                excluded=1
-                break
-                ;;
-            esac
-          done <<EOF
-$excludes
-EOF
-        fi
-
-        # Skip if excluded
-        [ "$excluded" -eq 1 ] && continue
-
-        # Determine destination path
-        local dest_file
-        if [ "$preserve_paths" = "true" ]; then
-          dest_file="$dst_root/$file"
-        else
-          dest_file="$dst_root/$(basename "$file")"
-        fi
-
-        # Create destination directory (skip in dry-run mode)
-        local dest_dir
-        dest_dir=$(dirname "$dest_file")
-
-        # Copy the file (or show what would be copied in dry-run mode)
-        if [ "$dry_run" = "true" ]; then
-          log_info "[dry-run] Would copy: $file"
-          copied_count=$((copied_count + 1))
-        else
-          mkdir -p "$dest_dir"
-          if cp "$file" "$dest_file" 2>/dev/null; then
-            log_info "Copied $file"
-            copied_count=$((copied_count + 1))
-          else
-            log_warn "Failed to copy $file"
-          fi
-        fi
-      done <<EOF
-$(find . -path "./$pattern" -type f 2>/dev/null)
-EOF
+    # Determine destination path
+    local dest_file
+    if [ "$preserve_paths" = "true" ]; then
+      dest_file="$dst_root/$file"
     else
-      # Use native Bash glob expansion (supports ** if available)
-      for file in $pattern; do
-        # Skip if not a file
-        [ -f "$file" ] || continue
+      dest_file="$dst_root/$(basename "$file")"
+    fi
 
-        # Remove leading ./
-        file="${file#./}"
-
-        # Check if file matches any exclude pattern
-        local excluded=0
-        if [ -n "$excludes" ]; then
-          while IFS= read -r exclude_pattern; do
-            [ -z "$exclude_pattern" ] && continue
-            # Intentional glob pattern matching for file exclusion
-            # shellcheck disable=SC2254
-            case "$file" in
-              $exclude_pattern)
-                excluded=1
-                break
-                ;;
-            esac
-          done <<EOF
-$excludes
-EOF
-        fi
-
-        # Skip if excluded
-        [ "$excluded" -eq 1 ] && continue
-
-        # Determine destination path
-        local dest_file
-        if [ "$preserve_paths" = "true" ]; then
-          dest_file="$dst_root/$file"
-        else
-          dest_file="$dst_root/$(basename "$file")"
-        fi
-
-        # Create destination directory (skip in dry-run mode)
-        local dest_dir
-        dest_dir=$(dirname "$dest_file")
-
-        # Copy the file (or show what would be copied in dry-run mode)
-        if [ "$dry_run" = "true" ]; then
-          log_info "[dry-run] Would copy: $file"
-          copied_count=$((copied_count + 1))
-        else
-          mkdir -p "$dest_dir"
-          if cp "$file" "$dest_file" 2>/dev/null; then
-            log_info "Copied $file"
-            copied_count=$((copied_count + 1))
-          else
-            log_warn "Failed to copy $file"
-          fi
-        fi
-      done
+    if [ "$dry_run" = "true" ]; then
+      log_info "[dry-run] Would copy: $file"
+      copied_count=$((copied_count + 1))
+    else
+      local dest_dir
+      dest_dir=$(dirname "$dest_file")
+      mkdir -p "$dest_dir"
+      if cp "$src_root/$file" "$dest_file" 2>/dev/null; then
+        log_info "Copied $file"
+        copied_count=$((copied_count + 1))
+      else
+        log_warn "Failed to copy $file"
+      fi
     fi
   done <<EOF
-$includes
+$(_expand_file_patterns "$src_root" "$includes" "$excludes")
 EOF
-
-  # Restore previous shell options
-  eval "$shopt_save" 2>/dev/null || true
-
-  cd "$old_pwd" || return 1
 
   if [ "$copied_count" -gt 0 ]; then
     if [ "$dry_run" = "true" ]; then
@@ -373,6 +345,156 @@ EOF
 
   if [ "$copied_count" -gt 0 ]; then
     log_info "Copied $copied_count directories"
+  fi
+
+  return 0
+}
+
+# Create symlinks for files matching patterns from source to destination
+# Usage: symlink_patterns src_root dst_root includes excludes [dry_run]
+# includes: newline-separated glob patterns to symlink
+# excludes: newline-separated glob patterns to exclude (reuses gtr.copy.exclude)
+# dry_run: true to only show what would be symlinked without creating symlinks
+symlink_patterns() {
+  local src_root="$1"
+  local dst_root="$2"
+  local includes="$3"
+  local excludes="${4:-}"
+  local dry_run="${5:-false}"
+
+  if [ -z "$includes" ]; then
+    return 0
+  fi
+
+  local symlink_count=0
+  local file
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+
+    local dest_file="$dst_root/$file"
+
+    if [ "$dry_run" = "true" ]; then
+      log_info "[dry-run] Would symlink: $file"
+      symlink_count=$((symlink_count + 1))
+      continue
+    fi
+
+    # Check if destination already exists
+    if [ -e "$dest_file" ] || [ -L "$dest_file" ]; then
+      if [ -L "$dest_file" ]; then
+        # Already a symlink — update it
+        ln -sf "$src_root/$file" "$dest_file"
+        log_info "Updated symlink: $file"
+        symlink_count=$((symlink_count + 1))
+      else
+        # Regular file — warn and skip
+        log_warn "Skipping $file (destination exists and is not a symlink)"
+      fi
+    else
+      local dest_dir
+      dest_dir=$(dirname "$dest_file")
+      mkdir -p "$dest_dir"
+      ln -s "$src_root/$file" "$dest_file"
+      log_info "Symlinked $file"
+      symlink_count=$((symlink_count + 1))
+    fi
+  done <<EOF
+$(_expand_file_patterns "$src_root" "$includes" "$excludes")
+EOF
+
+  if [ "$symlink_count" -gt 0 ]; then
+    if [ "$dry_run" = "true" ]; then
+      log_info "[dry-run] Would symlink $symlink_count file(s)"
+    else
+      log_info "Symlinked $symlink_count file(s)"
+    fi
+  fi
+
+  return 0
+}
+
+# Create symlinks for directories matching patterns
+# Usage: symlink_directories src_root dst_root dir_patterns [dry_run]
+# dir_patterns: newline-separated directory names to symlink
+symlink_directories() {
+  local src_root="$1"
+  local dst_root="$2"
+  local dir_patterns="$3"
+  local dry_run="${4:-false}"
+
+  if [ -z "$dir_patterns" ]; then
+    return 0
+  fi
+
+  # Change to source directory
+  local old_pwd
+  old_pwd=$(pwd)
+  cd "$src_root" || return 1
+
+  local symlink_count=0
+
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+
+    # Security: reject absolute paths and parent directory traversal
+    case "$pattern" in
+      /*|*/../*|../*|*/..|..)
+        log_warn "Skipping unsafe pattern: $pattern"
+        continue
+        ;;
+    esac
+
+    # Find directories matching the pattern
+    while IFS= read -r dir_path; do
+      [ -z "$dir_path" ] && continue
+      dir_path="${dir_path#./}"
+
+      # Ensure source directory exists
+      [ ! -d "$dir_path" ] && continue
+
+      local dest_dir="$dst_root/$dir_path"
+
+      if [ "$dry_run" = "true" ]; then
+        log_info "[dry-run] Would symlink directory: $dir_path"
+        symlink_count=$((symlink_count + 1))
+        continue
+      fi
+
+      # Check if destination already exists
+      if [ -e "$dest_dir" ] || [ -L "$dest_dir" ]; then
+        if [ -L "$dest_dir" ]; then
+          # Already a symlink — update it
+          ln -sfn "$src_root/$dir_path" "$dest_dir"
+          log_info "Updated directory symlink: $dir_path"
+          symlink_count=$((symlink_count + 1))
+        else
+          # Regular directory — warn and skip
+          log_warn "Skipping directory $dir_path (destination exists and is not a symlink)"
+        fi
+      else
+        local dest_parent
+        dest_parent=$(dirname "$dest_dir")
+        mkdir -p "$dest_parent"
+        ln -s "$src_root/$dir_path" "$dest_dir"
+        log_info "Symlinked directory $dir_path"
+        symlink_count=$((symlink_count + 1))
+      fi
+    done <<EOF
+$(if [[ "$pattern" == */* ]]; then find . -type d -path "./$pattern" 2>/dev/null; else find . -type d -name "$pattern" 2>/dev/null; fi)
+EOF
+  done <<EOF
+$dir_patterns
+EOF
+
+  cd "$old_pwd" || return 1
+
+  if [ "$symlink_count" -gt 0 ]; then
+    if [ "$dry_run" = "true" ]; then
+      log_info "[dry-run] Would symlink $symlink_count director$([ "$symlink_count" -eq 1 ] && echo 'y' || echo 'ies')"
+    else
+      log_info "Symlinked $symlink_count director$([ "$symlink_count" -eq 1 ] && echo 'y' || echo 'ies')"
+    fi
   fi
 
   return 0


### PR DESCRIPTION
## Summary

- **Unified file-pattern expansion** — `copy_patterns()` and `symlink_patterns()` now share `_expand_file_patterns()`, eliminating duplicated glob/exclude logic
- **`gtr.copy.exclude` now applies to symlinks** — previously excludes were silently ignored for `symlink_patterns`, meaning files the user explicitly excluded would still get symlinked. Real-world examples:
  - Symlink `.claude/**` but exclude `.claude/credentials.json` (per-worktree overrides)
  - Symlink `.vscode/**` but exclude `.vscode/launch.json` (debug configs differ per worktree)
  - Symlink `.config/**` but exclude `.config/secret.key`
- **Inlined `_check_exclude_and_emit()`** — the helper was only called from `_expand_file_patterns()`, so the function call indirection added per-file overhead without justification
- **New config keys**: `gtr.symlink.include`, `gtr.symlink.includeDirs` for declarative symlink patterns
- **Completions updated** for all three shells (bash, zsh, fish)

## Test plan

- [x] Create worktree with `gtr.copy.include` + `gtr.copy.exclude` — included files copied, excluded files skipped
- [x] Create worktree with `gtr.symlink.include` + `gtr.copy.exclude` — included files symlinked, excluded files skipped
- [x] Dry-run copy shows correct file list
- [x] `gtr list` displays worktrees correctly
- [x] `gtr rm` cleans up worktrees

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added symlink support for copying files between worktrees using -s/--symlink flag
  * Added --no-symlink flag to skip symlink creation during new worktree creation
  * New configuration options for controlling symlink include patterns and directories

* **Documentation**
  * Updated help text and command-line completions for new symlink flags
  * Added workflow examples demonstrating symlink usage scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->