### PR TITLE
refactor(copy): extract _expand_file_patterns() from copy_patterns()

### DIFF
--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -15,6 +15,102 @@ parse_pattern_file() {
   grep -v '^#' "$file_path" 2>/dev/null | grep -v '^[[:space:]]*$' || true
 }
 
+# Expand glob patterns against a source directory, filtering excludes.
+# Outputs matched file paths to stdout (one per line, relative to src_root).
+# Usage: _expand_file_patterns src_root includes [excludes]
+# Internal helper — callers iterate output and perform the file operation.
+_expand_file_patterns() {
+  local src_root="$1"
+  local includes="$2"
+  local excludes="${3:-}"
+
+  if [ -z "$includes" ]; then
+    return 0
+  fi
+
+  # Change to source directory
+  local old_pwd
+  old_pwd=$(pwd)
+  cd "$src_root" || return 1
+
+  # Save and configure shell options
+  local shopt_save
+  shopt_save="$(shopt -p nullglob dotglob globstar 2>/dev/null || true)"
+
+  local have_globstar=0
+  if shopt -s globstar 2>/dev/null; then
+    have_globstar=1
+  fi
+  shopt -s nullglob dotglob 2>/dev/null || true
+
+  # Process each include pattern
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+
+    # Security: reject absolute paths and parent directory traversal
+    case "$pattern" in
+      /*|*/../*|../*|*/..|..)
+        log_warn "Skipping unsafe pattern (absolute path or '..' path segment): $pattern"
+        continue
+        ;;
+    esac
+
+    # Collect matched files into a list, then filter
+    # Detect if pattern uses ** (requires globstar)
+    if [ "$have_globstar" -eq 0 ] && echo "$pattern" | grep -q '\*\*'; then
+      # Fallback to find for ** patterns on Bash 3.2
+      while IFS= read -r file; do
+        file="${file#./}"
+        # Check excludes and emit
+        local excluded=0
+        if [ -n "$excludes" ]; then
+          while IFS= read -r exclude_pattern; do
+            [ -z "$exclude_pattern" ] && continue
+            # shellcheck disable=SC2254
+            case "$file" in
+              $exclude_pattern) excluded=1; break ;;
+            esac
+          done <<EXCL
+$excludes
+EXCL
+        fi
+        [ "$excluded" -eq 0 ] && echo "$file"
+      done <<EOF
+$(find . -path "./$pattern" -type f 2>/dev/null)
+EOF
+    else
+      # Use native Bash glob expansion
+      for file in $pattern; do
+        [ -f "$file" ] || continue
+        file="${file#./}"
+        # Check excludes and emit
+        local excluded=0
+        if [ -n "$excludes" ]; then
+          while IFS= read -r exclude_pattern; do
+            [ -z "$exclude_pattern" ] && continue
+            # shellcheck disable=SC2254
+            case "$file" in
+              $exclude_pattern) excluded=1; break ;;
+            esac
+          done <<EXCL
+$excludes
+EXCL
+        fi
+        [ "$excluded" -eq 0 ] && echo "$file"
+      done
+    fi
+  done <<EOF
+$includes
+EOF
+
+  # Restore previous shell options
+  eval "$shopt_save" 2>/dev/null || true
+  cd "$old_pwd" || return 1
+
+  return 0
+}
+
+
 # Copy files matching patterns from source to destination
 # Usage: copy_patterns src_root dst_root includes excludes [preserve_paths] [dry_run]
 # includes: newline-separated glob patterns to include
@@ -30,164 +126,40 @@ copy_patterns() {
   local dry_run="${6:-false}"
 
   if [ -z "$includes" ]; then
-    # No patterns to copy
     return 0
   fi
 
-  # Change to source directory
-  local old_pwd
-  old_pwd=$(pwd)
-  cd "$src_root" || return 1
-
-  # Save current shell options
-  local shopt_save
-  shopt_save="$(shopt -p nullglob dotglob globstar 2>/dev/null || true)"
-
-  # Try to enable globstar for ** patterns (Bash 4.0+)
-  # nullglob: patterns that don't match expand to nothing
-  # dotglob: * matches hidden files
-  # globstar: ** matches directories recursively
-  local have_globstar=0
-  if shopt -s globstar 2>/dev/null; then
-    have_globstar=1
-  fi
-  shopt -s nullglob dotglob 2>/dev/null || true
-
   local copied_count=0
+  local file
 
-  # Process each include pattern (avoid pipeline subshell)
-  while IFS= read -r pattern; do
-    [ -z "$pattern" ] && continue
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
 
-    # Security: reject absolute paths and parent directory traversal
-    case "$pattern" in
-      /*|*/../*|../*|*/..|..)
-        log_warn "Skipping unsafe pattern (absolute path or '..' path segment): $pattern"
-        continue
-        ;;
-    esac
-
-    # Detect if pattern uses ** (requires globstar)
-    if [ "$have_globstar" -eq 0 ] && echo "$pattern" | grep -q '\*\*'; then
-      # Fallback to find for ** patterns on Bash 3.2
-      while IFS= read -r file; do
-        # Remove leading ./
-        file="${file#./}"
-
-        # Check if file matches any exclude pattern
-        local excluded=0
-        if [ -n "$excludes" ]; then
-          while IFS= read -r exclude_pattern; do
-            [ -z "$exclude_pattern" ] && continue
-            # Intentional glob pattern matching for file exclusion
-            # shellcheck disable=SC2254
-            case "$file" in
-              $exclude_pattern)
-                excluded=1
-                break
-                ;;
-            esac
-          done <<EOF
-$excludes
-EOF
-        fi
-
-        # Skip if excluded
-        [ "$excluded" -eq 1 ] && continue
-
-        # Determine destination path
-        local dest_file
-        if [ "$preserve_paths" = "true" ]; then
-          dest_file="$dst_root/$file"
-        else
-          dest_file="$dst_root/$(basename "$file")"
-        fi
-
-        # Create destination directory (skip in dry-run mode)
-        local dest_dir
-        dest_dir=$(dirname "$dest_file")
-
-        # Copy the file (or show what would be copied in dry-run mode)
-        if [ "$dry_run" = "true" ]; then
-          log_info "[dry-run] Would copy: $file"
-          copied_count=$((copied_count + 1))
-        else
-          mkdir -p "$dest_dir"
-          if cp "$file" "$dest_file" 2>/dev/null; then
-            log_info "Copied $file"
-            copied_count=$((copied_count + 1))
-          else
-            log_warn "Failed to copy $file"
-          fi
-        fi
-      done <<EOF
-$(find . -path "./$pattern" -type f 2>/dev/null)
-EOF
+    # Determine destination path
+    local dest_file
+    if [ "$preserve_paths" = "true" ]; then
+      dest_file="$dst_root/$file"
     else
-      # Use native Bash glob expansion (supports ** if available)
-      for file in $pattern; do
-        # Skip if not a file
-        [ -f "$file" ] || continue
+      dest_file="$dst_root/$(basename "$file")"
+    fi
 
-        # Remove leading ./
-        file="${file#./}"
-
-        # Check if file matches any exclude pattern
-        local excluded=0
-        if [ -n "$excludes" ]; then
-          while IFS= read -r exclude_pattern; do
-            [ -z "$exclude_pattern" ] && continue
-            # Intentional glob pattern matching for file exclusion
-            # shellcheck disable=SC2254
-            case "$file" in
-              $exclude_pattern)
-                excluded=1
-                break
-                ;;
-            esac
-          done <<EOF
-$excludes
-EOF
-        fi
-
-        # Skip if excluded
-        [ "$excluded" -eq 1 ] && continue
-
-        # Determine destination path
-        local dest_file
-        if [ "$preserve_paths" = "true" ]; then
-          dest_file="$dst_root/$file"
-        else
-          dest_file="$dst_root/$(basename "$file")"
-        fi
-
-        # Create destination directory (skip in dry-run mode)
-        local dest_dir
-        dest_dir=$(dirname "$dest_file")
-
-        # Copy the file (or show what would be copied in dry-run mode)
-        if [ "$dry_run" = "true" ]; then
-          log_info "[dry-run] Would copy: $file"
-          copied_count=$((copied_count + 1))
-        else
-          mkdir -p "$dest_dir"
-          if cp "$file" "$dest_file" 2>/dev/null; then
-            log_info "Copied $file"
-            copied_count=$((copied_count + 1))
-          else
-            log_warn "Failed to copy $file"
-          fi
-        fi
-      done
+    if [ "$dry_run" = "true" ]; then
+      log_info "[dry-run] Would copy: $file"
+      copied_count=$((copied_count + 1))
+    else
+      local dest_dir
+      dest_dir=$(dirname "$dest_file")
+      mkdir -p "$dest_dir"
+      if cp "$src_root/$file" "$dest_file" 2>/dev/null; then
+        log_info "Copied $file"
+        copied_count=$((copied_count + 1))
+      else
+        log_warn "Failed to copy $file"
+      fi
     fi
   done <<EOF
-$includes
+$(_expand_file_patterns "$src_root" "$includes" "$excludes")
 EOF
-
-  # Restore previous shell options
-  eval "$shopt_save" 2>/dev/null || true
-
-  cd "$old_pwd" || return 1
 
   if [ "$copied_count" -gt 0 ]; then
     if [ "$dry_run" = "true" ]; then


### PR DESCRIPTION
## Summary

- Extracts glob expansion + exclude filtering from `copy_patterns()` into a new `_expand_file_patterns()` internal helper
- `copy_patterns()` is reduced from ~150 lines (pattern matching + file I/O interleaved) to ~50 lines of pure I/O iteration
- No behavior changes — same glob semantics, same exclude filtering, same Bash 3.2 `find` fallback for `**` patterns

This was originally part of #106 which also added symlink support. After discussion, the symlink feature was dropped (hooks cover the use case), but this internal cleanup is worth keeping on its own.

## Test plan

- [x] `gtr new` with `gtr.copy.include` + `gtr.copy.exclude` — included files copied, excluded files skipped
- [x] `gtr copy --dry-run` — shows correct files
- [x] `gtr rm` — clean removal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal file pattern processing to improve code organization and reliability
  * Enhanced safety validation for path operations to prevent invalid inputs
  * Decoupled pattern expansion from file execution steps for improved maintainability
  * Optimized workflow to better separate concerns in the file handling process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->