### PR TITLE
fix(completions): remove ghost flag and add missing completions

### DIFF
--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -83,6 +83,16 @@ complete -c git -n '__fish_git_gtr_using_command copy' -s n -l dry-run -d 'Previ
 complete -c git -n '__fish_git_gtr_using_command copy' -s a -l all -d 'Copy to all worktrees'
 complete -c git -n '__fish_git_gtr_using_command copy' -l from -d 'Source worktree' -r
 
+# List command options
+complete -c git -n '__fish_git_gtr_using_command list' -l porcelain -d 'Machine-readable output'
+complete -c git -n '__fish_git_gtr_using_command ls' -l porcelain -d 'Machine-readable output'
+
+# Editor command options
+complete -c git -n '__fish_git_gtr_using_command editor' -l editor -d 'Editor to use' -r -a 'cursor vscode zed idea pycharm webstorm vim nvim emacs sublime nano atom none'
+
+# AI command options
+complete -c git -n '__fish_git_gtr_using_command ai' -l ai -d 'AI tool to use' -r -a 'aider auggie claude codex continue copilot cursor gemini opencode none'
+
 # Clean command options
 complete -c git -n '__fish_git_gtr_using_command clean' -l merged -d 'Remove worktrees with merged PRs/MRs'
 complete -c git -n '__fish_git_gtr_using_command clean' -l yes -d 'Skip confirmation prompts'

--- a/completions/gtr.bash
+++ b/completions/gtr.bash
@@ -30,7 +30,7 @@ _git_gtr() {
 
   # Commands that take branch names or '1' for main repo
   case "$cmd" in
-    go|run|editor|ai|rm|mv|rename)
+    go|run|rm|mv|rename)
       if [ "$cword" -eq 3 ]; then
         # Complete with branch names and special ID '1' for main repo
         local branches all_options
@@ -46,6 +46,35 @@ _git_gtr() {
             COMPREPLY=($(compgen -W "--force --yes" -- "$cur"))
             ;;
         esac
+      fi
+      ;;
+    editor)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--editor" -- "$cur"))
+      elif [ "$prev" = "--editor" ]; then
+        COMPREPLY=($(compgen -W "cursor vscode zed idea pycharm webstorm vim nvim emacs sublime nano atom none" -- "$cur"))
+      else
+        local branches all_options
+        branches=$(git branch --format='%(refname:short)' 2>/dev/null || true)
+        all_options="1 $branches"
+        COMPREPLY=($(compgen -W "$all_options" -- "$cur"))
+      fi
+      ;;
+    ai)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--ai" -- "$cur"))
+      elif [ "$prev" = "--ai" ]; then
+        COMPREPLY=($(compgen -W "aider auggie claude codex continue copilot cursor gemini opencode none" -- "$cur"))
+      else
+        local branches all_options
+        branches=$(git branch --format='%(refname:short)' 2>/dev/null || true)
+        all_options="1 $branches"
+        COMPREPLY=($(compgen -W "$all_options" -- "$cur"))
+      fi
+      ;;
+    ls|list)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "--porcelain" -- "$cur"))
       fi
       ;;
     clean)
@@ -67,7 +96,7 @@ _git_gtr() {
     new)
       # Complete flags
       if [[ "$cur" == -* ]]; then
-        COMPREPLY=($(compgen -W "--id --from --from-current --track --no-copy --no-fetch --no-hooks --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
+        COMPREPLY=($(compgen -W "--from --from-current --track --no-copy --no-fetch --no-hooks --force --name --folder --yes --editor -e --ai -a" -- "$cur"))
       elif [ "$prev" = "--track" ]; then
         COMPREPLY=($(compgen -W "auto remote local none" -- "$cur"))
       fi


### PR DESCRIPTION
## Summary

- Remove `--id` ghost flag from Bash completions (never existed in code, likely leftover from earlier design)
- Add `--porcelain` completion for `list`/`ls` in Bash and Fish (already present in Zsh)
- Add `--editor` flag with adapter name completions for `editor` command in Bash and Fish
- Add `--ai` flag with adapter name completions for `ai` command in Bash and Fish

Brings Bash and Fish completions to parity with Zsh.

## Test plan

- [ ] Source `completions/gtr.bash` in Bash, verify `git gtr new --<TAB>` no longer shows `--id`
- [ ] Verify `git gtr list --<TAB>` shows `--porcelain` in Bash
- [ ] Verify `git gtr editor --<TAB>` shows `--editor` in Bash
- [ ] Verify `git gtr editor --editor <TAB>` shows adapter names in Bash
- [ ] Verify `git gtr ai --<TAB>` shows `--ai` in Bash
- [ ] Source Fish completions, verify same behaviors in Fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced shell completions for git gtr tool across multiple commands
  * list/ls commands now support porcelain flag completion
  * editor command provides editor selection autocomplete
  * ai command provides AI tool selection autocomplete
  * clean command gains additional flag completions
  * new command receives refined flag completion options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->