### PR TITLE
refactor: extract resolve_repo_context helper

### DIFF
--- a/bin/gtr
+++ b/bin/gtr
@@ -229,12 +229,8 @@ cmd_create() {
   fi
 
   # Get repo info
-  local repo_root
-  repo_root=$(discover_repo_root) || exit 1
-
-  local base_dir prefix
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Get branch name if not provided
   if [ -z "$branch_name" ]; then
@@ -437,10 +433,8 @@ cmd_remove() {
     exit 1
   fi
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   for identifier in $identifiers; do
     # Resolve target branch
@@ -536,10 +530,8 @@ cmd_rename() {
     exit 1
   fi
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve old worktree
   local target is_main old_path old_branch
@@ -624,10 +616,8 @@ cmd_go() {
   fi
 
   local identifier="$1"
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve target branch
   local target is_main worktree_path branch
@@ -684,10 +674,8 @@ cmd_run() {
     exit 1
   fi
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve target branch
   local target is_main worktree_path branch
@@ -763,10 +751,8 @@ cmd_copy() {
   fi
 
   # Get repo context
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve source path
   local src_target src_path
@@ -868,10 +854,8 @@ cmd_editor() {
     editor=$(cfg_default gtr.editor.default GTR_EDITOR_DEFAULT "none" defaults.editor)
   fi
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve target branch
   local target worktree_path branch
@@ -944,10 +928,8 @@ cmd_ai() {
   # Load AI adapter
   load_ai_adapter "$ai_tool"
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   # Resolve target branch
   local target worktree_path branch
@@ -1080,10 +1062,8 @@ cmd_clean() {
     log_info "Pruned stale worktree administrative files"
   fi
 
-  local repo_root base_dir prefix
-  repo_root=$(discover_repo_root) || exit 1
-  base_dir=$(resolve_base_dir "$repo_root")
-  prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+  resolve_repo_context || exit 1
+  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
 
   if [ ! -d "$base_dir" ]; then
     log_info "No worktrees directory to clean"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -457,6 +457,15 @@ list_worktrees() {
 }
 
 # List all worktree branch names (excluding main repo)
+# Resolve common repo context used by most cmd_* handlers.
+# Sets globals: _ctx_repo_root, _ctx_base_dir, _ctx_prefix
+# Usage: resolve_repo_context || exit 1
+resolve_repo_context() {
+  _ctx_repo_root=$(discover_repo_root) || return 1
+  _ctx_base_dir=$(resolve_base_dir "$_ctx_repo_root")
+  _ctx_prefix=$(cfg_default gtr.worktrees.prefix GTR_WORKTREES_PREFIX "")
+}
+
 # Usage: list_worktree_branches base_dir prefix
 # Returns: newline-separated list of branch names
 list_worktree_branches() {


### PR DESCRIPTION
## Summary

- Add `resolve_repo_context()` to `lib/core.sh` that sets `_ctx_repo_root`, `_ctx_base_dir`, `_ctx_prefix`
- Replace the duplicated 3-line boilerplate across 9 `cmd_*` handlers in `bin/gtr`
- Net: +27 lines, -38 lines (11 lines removed)

Intentionally skipped `cmd_list` (different error handling: `|| return 0`) and `cmd_doctor` (conditional pattern).

## Test plan

- [ ] `git gtr new test-feature` — creates worktree
- [ ] `git gtr list` — lists worktrees
- [ ] `git gtr go test-feature` — prints path
- [ ] `git gtr run test-feature git status` — runs command in worktree
- [ ] `git gtr rm test-feature` — removes worktree
- [ ] `git gtr clean` — prunes stale worktrees
- [ ] `git gtr doctor` — health check still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for repository context initialization to enhance consistency across command handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->