### PR TITLE
refactor: extract _clean_merged from cmd_clean

### DIFF
--- a/bin/gtr
+++ b/bin/gtr
@@ -1043,6 +1043,116 @@ cmd_list() {
 }
 
 # Clean command (remove prunable worktrees)
+# Remove worktrees whose PRs/MRs are merged (handles squash merges)
+# Usage: _clean_merged repo_root base_dir prefix yes_mode dry_run
+_clean_merged() {
+  local repo_root="$1" base_dir="$2" prefix="$3" yes_mode="$4" dry_run="$5"
+
+  log_step "Checking for worktrees with merged PRs/MRs..."
+
+  # Detect hosting provider (GitHub, GitLab, etc.)
+  local provider
+  provider=$(detect_provider) || true
+  if [ -z "$provider" ]; then
+    local remote_url
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [ -z "$remote_url" ]; then
+      log_error "No remote URL configured for 'origin'"
+    else
+      # Sanitize URL to avoid leaking embedded credentials (e.g., https://token@host/...)
+      local safe_url="${remote_url%%@*}"
+      if [ "$safe_url" != "$remote_url" ]; then
+        safe_url="<redacted>@${remote_url#*@}"
+      fi
+      log_error "Could not detect hosting provider from remote URL: $safe_url"
+      log_info "Set manually: git gtr config set gtr.provider github  (or gitlab)"
+    fi
+    exit 1
+  fi
+
+  # Ensure provider CLI is available and authenticated
+  ensure_provider_cli "$provider" || exit 1
+
+  # Fetch latest from origin
+  log_step "Fetching from origin..."
+  git fetch origin --prune 2>/dev/null || log_warn "Could not fetch from origin"
+
+  local removed=0
+  local skipped=0
+
+  # Get main repo branch to exclude it
+  local main_branch
+  main_branch=$(current_branch "$repo_root")
+
+  # Iterate through worktree directories
+  for dir in "$base_dir/${prefix}"*; do
+    [ -d "$dir" ] || continue
+
+    local branch
+    branch=$(current_branch "$dir")
+
+    if [ -z "$branch" ] || [ "$branch" = "(detached)" ]; then
+      log_warn "Skipping $dir (detached HEAD)"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Skip if same as main repo branch
+    if [ "$branch" = "$main_branch" ]; then
+      continue
+    fi
+
+    # Check if worktree has uncommitted changes
+    if ! git -C "$dir" diff --quiet 2>/dev/null || \
+       ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
+      log_warn "Skipping $branch (has uncommitted changes)"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Check for untracked files
+    if [ -n "$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null)" ]; then
+      log_warn "Skipping $branch (has untracked files)"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    # Check if branch has a merged PR/MR
+    if check_branch_merged "$provider" "$branch"; then
+      if [ "$dry_run" -eq 1 ]; then
+        log_info "[dry-run] Would remove: $branch ($dir)"
+        removed=$((removed + 1))
+      elif [ "$yes_mode" -eq 1 ] || prompt_yes_no "Remove worktree and delete branch '$branch'?"; then
+        log_step "Removing worktree: $branch"
+        local remove_output
+        if remove_output=$(git worktree remove "$dir" 2>&1); then
+          # Also delete the local branch
+          git branch -d "$branch" 2>/dev/null || git branch -D "$branch" 2>/dev/null || true
+          log_info "Removed: $branch"
+          removed=$((removed + 1))
+        else
+          if [ -n "$remove_output" ]; then
+            log_error "Failed to remove worktree: $remove_output"
+          else
+            log_error "Failed to remove worktree: $branch"
+          fi
+        fi
+      else
+        log_warn "Skipped: $branch (user declined)"
+        skipped=$((skipped + 1))
+      fi
+    fi
+    # Branches without merged PRs are silently skipped (this is the normal case)
+  done
+
+  echo ""
+  if [ "$dry_run" -eq 1 ]; then
+    log_info "Dry run complete. Would remove: $removed, Skipped: $skipped"
+  else
+    log_info "Merged cleanup complete. Removed: $removed, Skipped: $skipped"
+  fi
+}
+
 cmd_clean() {
   local merged_mode=0
   local yes_mode=0
@@ -1116,109 +1226,7 @@ EOF
 
   # --merged mode: remove worktrees with merged PRs/MRs (handles squash merges)
   if [ "$merged_mode" -eq 1 ]; then
-    log_step "Checking for worktrees with merged PRs/MRs..."
-
-    # Detect hosting provider (GitHub, GitLab, etc.)
-    local provider
-    provider=$(detect_provider) || true
-    if [ -z "$provider" ]; then
-      local remote_url
-      remote_url=$(git remote get-url origin 2>/dev/null || true)
-      if [ -z "$remote_url" ]; then
-        log_error "No remote URL configured for 'origin'"
-      else
-        # Sanitize URL to avoid leaking embedded credentials (e.g., https://token@host/...)
-        local safe_url="${remote_url%%@*}"
-        if [ "$safe_url" != "$remote_url" ]; then
-          safe_url="<redacted>@${remote_url#*@}"
-        fi
-        log_error "Could not detect hosting provider from remote URL: $safe_url"
-        log_info "Set manually: git gtr config set gtr.provider github  (or gitlab)"
-      fi
-      exit 1
-    fi
-
-    # Ensure provider CLI is available and authenticated
-    ensure_provider_cli "$provider" || exit 1
-
-    # Fetch latest from origin
-    log_step "Fetching from origin..."
-    git fetch origin --prune 2>/dev/null || log_warn "Could not fetch from origin"
-
-    local removed=0
-    local skipped=0
-
-    # Get main repo branch to exclude it
-    local main_branch
-    main_branch=$(current_branch "$repo_root")
-
-    # Iterate through worktree directories
-    for dir in "$base_dir/${prefix}"*; do
-      [ -d "$dir" ] || continue
-
-      local branch
-      branch=$(current_branch "$dir")
-
-      if [ -z "$branch" ] || [ "$branch" = "(detached)" ]; then
-        log_warn "Skipping $dir (detached HEAD)"
-        skipped=$((skipped + 1))
-        continue
-      fi
-
-      # Skip if same as main repo branch
-      if [ "$branch" = "$main_branch" ]; then
-        continue
-      fi
-
-      # Check if worktree has uncommitted changes
-      if ! git -C "$dir" diff --quiet 2>/dev/null || \
-         ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
-        log_warn "Skipping $branch (has uncommitted changes)"
-        skipped=$((skipped + 1))
-        continue
-      fi
-
-      # Check for untracked files
-      if [ -n "$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null)" ]; then
-        log_warn "Skipping $branch (has untracked files)"
-        skipped=$((skipped + 1))
-        continue
-      fi
-
-      # Check if branch has a merged PR/MR
-      if check_branch_merged "$provider" "$branch"; then
-        if [ "$dry_run" -eq 1 ]; then
-          log_info "[dry-run] Would remove: $branch ($dir)"
-          removed=$((removed + 1))
-        elif [ "$yes_mode" -eq 1 ] || prompt_yes_no "Remove worktree and delete branch '$branch'?"; then
-          log_step "Removing worktree: $branch"
-          local remove_output
-          if remove_output=$(git worktree remove "$dir" 2>&1); then
-            # Also delete the local branch
-            git branch -d "$branch" 2>/dev/null || git branch -D "$branch" 2>/dev/null || true
-            log_info "Removed: $branch"
-            removed=$((removed + 1))
-          else
-            if [ -n "$remove_output" ]; then
-              log_error "Failed to remove worktree: $remove_output"
-            else
-              log_error "Failed to remove worktree: $branch"
-            fi
-          fi
-        else
-          log_warn "Skipped: $branch (user declined)"
-          skipped=$((skipped + 1))
-        fi
-      fi
-      # Branches without merged PRs are silently skipped (this is the normal case)
-    done
-
-    echo ""
-    if [ "$dry_run" -eq 1 ]; then
-      log_info "Dry run complete. Would remove: $removed, Skipped: $skipped"
-    else
-      log_info "Merged cleanup complete. Removed: $removed, Skipped: $skipped"
-    fi
+    _clean_merged "$repo_root" "$base_dir" "$prefix" "$yes_mode" "$dry_run"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Extract the `--merged` workflow (105 lines) from `cmd_clean` into `_clean_merged()`
- Handles provider detection, branch iteration, PR/MR status checking, and worktree removal
- `cmd_clean` now calls `_clean_merged` conditionally, reducing nesting from 5 levels to 2

## Test plan

- [ ] `git gtr clean` — standard prune + empty dir cleanup (unchanged)
- [ ] `git gtr clean --merged --dry-run` — shows what would be removed
- [ ] `git gtr clean --merged --yes` — auto-confirm removals
- [ ] `git gtr clean --merged` on repo with no origin — shows provider detection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured worktree cleanup logic for improved code organization and maintainability. Enhanced modularity of the merged worktree removal process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->