### PR TITLE
fix: resolve main repo root correctly from inside worktrees

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -10,12 +10,27 @@
 declare _ctx_repo_root _ctx_base_dir _ctx_prefix
 declare _ctx_is_main _ctx_worktree_path _ctx_branch
 
-# Discover the root of the current git repository
-# Returns: absolute path to repo root
+# Discover the root of the main git repository
+# Works correctly from both the main repo and from inside worktrees.
+# Returns: absolute path to main repo root
 # Exit code: 0 on success, 1 if not in a git repo
 discover_repo_root() {
-  local root
-  root=$(git rev-parse --show-toplevel 2>/dev/null)
+  local root git_common_dir
+  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+
+  if [ -z "$git_common_dir" ]; then
+    log_error "Not in a git repository"
+    return 1
+  fi
+
+  # --git-common-dir returns:
+  #   ".git" (relative) when in the main repo
+  #   "/absolute/path/to/repo/.git" when in a worktree
+  if [ "$git_common_dir" = ".git" ]; then
+    root=$(git rev-parse --show-toplevel 2>/dev/null)
+  else
+    root="${git_common_dir%/.git}"
+  fi
 
   if [ -z "$root" ]; then
     log_error "Not in a git repository"

--- a/tests/cmd_go.bats
+++ b/tests/cmd_go.bats
@@ -51,3 +51,10 @@ teardown() {
   # stderr should contain human-readable info
   [[ "$stderr" == *"Worktree"* ]] || [[ "$stderr" == *"Branch"* ]]
 }
+
+@test "cmd_go 1 from inside a worktree resolves to main repo" {
+  cd "$TEST_WORKTREES_DIR/go-test"
+  run cmd_go 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$TEST_REPO"* ]]
+}

--- a/tests/cmd_list.bats
+++ b/tests/cmd_list.bats
@@ -57,3 +57,22 @@ teardown() {
   [[ "$output" == *"BRANCH"* ]]
   [[ "$output" == *"PATH"* ]]
 }
+
+@test "cmd_list from inside a worktree shows all worktrees" {
+  create_test_worktree "wt-inside"
+  cd "$TEST_WORKTREES_DIR/wt-inside"
+  run cmd_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"[main repo]"* ]]
+  [[ "$output" == *"wt-inside"* ]]
+  [[ "$output" == *"$TEST_REPO"* ]]
+}
+
+@test "cmd_list --porcelain from inside a worktree includes main repo" {
+  create_test_worktree "wt-porcelain"
+  cd "$TEST_WORKTREES_DIR/wt-porcelain"
+  local output
+  output=$(cmd_list --porcelain)
+  [[ "$output" == *"$TEST_REPO"* ]]
+  [[ "$output" == *"wt-porcelain"* ]]
+}

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -80,3 +80,23 @@ teardown() {
   run resolve_worktree "nope" "$TEST_REPO" "$TEST_WORKTREES_DIR" ""
   [ "$status" -eq 1 ]
 }
+
+# ── discover_repo_root from worktree ──────────────────────────────────────────
+
+@test "discover_repo_root returns main repo root when called from a worktree" {
+  create_test_worktree "inside-wt"
+  cd "$TEST_WORKTREES_DIR/inside-wt"
+  local root expected
+  root=$(discover_repo_root)
+  # Resolve symlinks (macOS: /var -> /private/var) for comparison
+  expected=$(cd "$TEST_REPO" && pwd -P)
+  [ "$root" = "$expected" ]
+}
+
+@test "discover_repo_root returns main repo root when called from main repo" {
+  cd "$TEST_REPO"
+  local root expected
+  root=$(discover_repo_root)
+  expected=$(pwd -P)
+  [ "$root" = "$expected" ]
+}


### PR DESCRIPTION
## Summary

Closes #123

- `discover_repo_root()` used `git rev-parse --show-toplevel` which returns the worktree's own root when called from inside a worktree, breaking `list`, `go 1`, and all other commands
- Switched to `git rev-parse --git-common-dir` to always resolve the true main repo root (same technique already used by `_gtrconfig_path()` in `lib/config.sh`)
- Added 5 tests covering `discover_repo_root`, `cmd_list`, and `cmd_go` from inside a worktree

## Test plan

- [x] `bats tests/core_resolve_target.bats` — new `discover_repo_root` tests pass
- [x] `bats tests/cmd_list.bats` — new from-worktree tests pass
- [x] `bats tests/cmd_go.bats` — new from-worktree test passes
- [x] `bats tests/` — full suite (267 tests) passes with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved repository root detection to properly support git worktrees, ensuring all commands correctly identify the main repository when executed from within a worktree.

* **Tests**
  * Added comprehensive test coverage validating command behavior when executed inside git worktrees, including both standard and porcelain output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->