### PR TITLE
fix: resolve_target fallback via git worktree list for external worktrees

### DIFF
--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -81,6 +81,18 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
+# ── porcelain fallback ─────────────────────────────────────────────────────────
+
+@test "resolve_target finds externally-created worktree via porcelain fallback" {
+  # Create a worktree with raw git (outside gtr-managed directory)
+  local ext_dir="${TEST_REPO}-external"
+  git -C "$TEST_REPO" worktree add "$ext_dir" -b external-branch --quiet
+  local result
+  result=$(resolve_target "external-branch" "$TEST_REPO" "$TEST_WORKTREES_DIR" "")
+  # Assert: found with is_main=0, correct branch, path ends with expected suffix
+  [[ "$result" == "0"$'\t'*"-external"$'\t'"external-branch" ]]
+}
+
 # ── discover_repo_root from worktree ──────────────────────────────────────────
 
 @test "discover_repo_root returns main repo root when called from a worktree" {


### PR DESCRIPTION
## Summary

- Adds a `git worktree list --porcelain` fallback as the last step in `resolve_target()` before returning "not found"
- Catches worktrees created outside the gtr-managed directory (e.g. via raw `git worktree add /some/other/path -b feature`) that the existing directory scan cannot find
- Only runs when all existing fast paths fail — zero performance impact on the happy path

**Note:** Issue #127 was closed as already fixed by #123/#126 (`discover_repo_root` fix). This PR addresses a separate gap where `resolve_target` couldn't find worktrees stored outside the gtr-managed worktrees directory.

## Test plan

- [x] New BATS test: externally-created worktree found via porcelain fallback
- [x] Full test suite passes (271 tests)
- [x] Manual verification: `git worktree add /tmp/ext -b ext-branch` → `git gtr go ext-branch` succeeds
- [x] Manual verification: without fix, same scenario fails with "Worktree not found"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree resolution to locate externally-created worktrees when initial lookup fails, enhancing fallback behavior and error handling.
* **Tests**
  * Added coverage validating the fallback lookup for external worktrees and the reported worktree attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->