### PR TITLE
Fix Google's Antigravity support

### DIFF
--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -92,6 +92,15 @@ setup() {
   [ "$_EDITOR_BACKGROUND" -eq 1 ]
 }
 
+@test "_load_from_editor_registry parses antigravity with workspace and dot flags" {
+  local entry
+  entry=$(_registry_lookup "$_EDITOR_REGISTRY" "antigravity")
+  _load_from_editor_registry "$entry"
+  [ "$_EDITOR_CMD" = "agy" ]
+  [ "$_EDITOR_WORKSPACE" -eq 1 ]
+  [ "$_EDITOR_DOT" -eq 1 ]
+}
+
 # ── _load_from_ai_registry ──────────────────────────────────────────────────
 
 @test "_load_from_ai_registry parses aider entry correctly" {


### PR DESCRIPTION
# Pull Request

## Description

Fix issue where it is not opening in the right worktree directory anymore (needs `.` when calling).

## Motivation

Fix issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

### Manual Testing Checklist

**Tested on:**

- [x] macOS
- [ ] Linux (specify distro: \_\_\_\_\_\_)
- [ ] Windows (Git Bash)

**Core functionality tested:**

- [x] `git gtr new <branch>` - Create worktree
- [ ] `git gtr go <branch>` - Navigate to worktree
- [x] `git gtr editor <branch>` - Open in editor (if applicable)
- [ ] `git gtr ai <branch>` - Start AI tool (if applicable)
- [ ] `git gtr rm <branch>` - Remove worktree
- [x] `git gtr list` - List worktrees
- [x] `git gtr config` - Configuration commands (if applicable)
- [x] Other commands affected by this change: `git gtr adapter`, `git gtr help editor`

### Test Steps

1. Run existing BATS test suite: all 236/236 tests pass with no regressions
2. Run `git gtr adapter` and verify `antigravity` appears in the editor list
3. Run `git gtr help editor` and verify `antigravity` is listed among available editors
4. Run `./scripts/generate-completions.sh --check` and verify completions are in sync
5. Verify fish completion for `gtr.ui.color` now shows "Color output mode (auto, always, never)" description

**Expected behavior:** Antigravity appears as a built-in editor option in all help, adapter, completion, and configuration surfaces. Fish completion for `gtr.ui.color` shows the correct description.

**Actual behavior:** Matches expected behavior.

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] I have discussed this in an issue first
- [ ] Migration guide is included in documentation

## Checklist

Before submitting this PR, please check:

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] My code follows the project's style guidelines
- [x] I have performed manual testing on at least one platform
- [x] I have updated documentation (README.md, CLAUDE.md, etc.) if needed
- [x] My changes work on multiple platforms (or I've noted platform-specific behavior)
- [x] I have added/updated shell completions (if adding new commands or flags)
- [x] I have tested with both `git gtr` (production) and `./bin/gtr` (development)
- [x] No new external dependencies are introduced (Bash + git only)
- [x] All existing functionality still works

## Additional Context

**Files changed:**

- `lib/adapters.sh` — Added _EDITOR_DOT to denote need for adding `.` when opening the editor
---

## License Acknowledgment

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache License 2.0](../LICENSE.txt).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new dot mode modifier for editor adapters, enabling editors to launch with the current directory represented as "." instead of the full file path for more flexible path handling.

* **Tests**
  * Added test coverage validating proper parsing and behavior of the new dot mode modifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->