### PR TITLE
fix: show helpful error when running `git gtr cd`

### DIFF
--- a/bin/git-gtr
+++ b/bin/git-gtr
@@ -106,6 +106,14 @@ main() {
     help|--help|-h)
       cmd_help "$@"
       ;;
+    cd)
+      local _shell_name
+      _shell_name="$(basename "${SHELL:-bash}")"
+      log_error "'cd' requires shell integration (subprocesses cannot change your shell's directory)"
+      log_info "Set up with: eval \"\$(git gtr init $_shell_name)\""
+      log_info "Then use:    gtr cd [<branch>]"
+      exit 1
+      ;;
     *)
       log_error "Unknown command: $cmd"
       echo "Use 'git gtr help' for available commands"


### PR DESCRIPTION
## Summary
- `git gtr cd` now shows a clear error explaining why it doesn't work (subprocess limitation) instead of the generic "Unknown command" message
- Prints the exact `eval "$(git gtr init <shell>)"` setup command, auto-detecting the user's shell
- Guides users to use `gtr cd` (the shell function wrapper) instead

## Before
```
$ git gtr cd
[x] Unknown command: cd
Use 'git gtr help' for available commands
```

## After
```
$ git gtr cd
[x] 'cd' requires shell integration (subprocesses cannot change your shell's directory)
[i] Set up with: eval "$(git gtr init zsh)"
[i] Then use:    gtr cd [<branch>]
```

## Test plan
- [x] `git gtr cd` shows helpful error with shell-specific setup instructions
- [x] `gtr cd` (shell wrapper) still works normally
- [x] All 282 BATS tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling for the "cd" command with improved guidance on shell integration setup and initialization instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->