### PR TITLE
chore: prepare v2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-02-24
+
+### Added
+
+- Interactive fzf worktree picker for `gtr cd` with preview, keybindings, and multi-action support ([#136](https://github.com/coderabbitai/git-worktree-runner/pull/136))
+- Helpful error message when running `git gtr cd` explaining shell integration requirement ([#137](https://github.com/coderabbitai/git-worktree-runner/pull/137))
+
+### Changed
+
+- Limit `find` depth for simple directory copy patterns for better performance ([#130](https://github.com/coderabbitai/git-worktree-runner/pull/130))
+
+### Fixed
+
+- Root-level files now matched correctly for `**` glob patterns on Bash 3.2 ([#133](https://github.com/coderabbitai/git-worktree-runner/pull/133))
+- Antigravity adapter support ([#131](https://github.com/coderabbitai/git-worktree-runner/pull/131))
+
 ## [2.3.1] - 2026-02-17
 
 ### Added
@@ -140,7 +156,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Improved base directory resolution logic to distinguish `.` (repo root), `./path` (repo-internal) from other relative values (sibling directories)
 
-[Unreleased]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.3.1...HEAD
+[Unreleased]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.4.0...HEAD
+[2.4.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.1.0...v2.2.0

--- a/bin/git-gtr
+++ b/bin/git-gtr
@@ -11,7 +11,7 @@ if [ -n "${GTR_DEBUG:-}" ]; then
 fi
 
 # Version
-GTR_VERSION="2.3.1"
+GTR_VERSION="2.4.0"
 
 # Find the script directory (resolve symlinks; allow env override)
 resolve_script_dir() {


### PR DESCRIPTION
## Summary
- Bump version to 2.4.0
- Add v2.4.0 CHANGELOG entry (1 feature, 1 UX improvement, 1 perf improvement, 2 fixes)

## Changes in v2.4.0
- **Added**: Interactive fzf worktree picker for `gtr cd` (#136), helpful error for `git gtr cd` (#137)
- **Changed**: Limit find depth for simple directory patterns (#130)
- **Fixed**: Root-level file matching for `**` globs on Bash 3.2 (#133), Antigravity adapter (#131)

## After merge
```bash
git pull origin main
git tag -a v2.4.0 -m "v2.4.0"
git push origin v2.4.0
gh release create v2.4.0 --title "v2.4.0" --generate-notes --notes-start-tag v2.3.1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 2.4.0

* **Documentation**
  * Updated changelog with release notes documenting new features, changes, and bug fixes for version 2.4.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->