### PR TITLE
feat(ai): run postCd hooks before launching AI process

### DIFF
--- a/lib/commands/ai.sh
+++ b/lib/commands/ai.sh
@@ -39,5 +39,13 @@ cmd_ai() {
   log_info "Directory: $worktree_path"
   log_info "Branch: $branch"
 
-  ai_start "$worktree_path" "${ai_args[@]}"
+  # Run postCd hooks + AI in a subshell so hook env vars propagate to AI
+  (
+    cd "$worktree_path" || exit 1
+    run_hooks_export "postCd" \
+      REPO_ROOT="$repo_root" \
+      WORKTREE_PATH="$worktree_path" \
+      BRANCH="$branch"
+    ai_start "$worktree_path" "${ai_args[@]}"
+  )
 }

--- a/lib/commands/create.sh
+++ b/lib/commands/create.sh
@@ -192,7 +192,7 @@ cmd_create() {
 
   # Auto-launch editor/AI or show next steps
   [ "$open_editor" -eq 1 ] && { _auto_launch_editor "$worktree_path" || true; }
-  [ "$start_ai" -eq 1 ] && { _auto_launch_ai "$worktree_path" || true; }
+  [ "$start_ai" -eq 1 ] && { _auto_launch_ai "$worktree_path" "$repo_root" "$branch_name" || true; }
   if [ "$open_editor" -eq 0 ] && [ "$start_ai" -eq 0 ]; then
     _post_create_next_steps "$branch_name" "$folder_name" "$folder_override" "$repo_root" "$base_dir" "$prefix"
   fi


### PR DESCRIPTION
## Summary

- `gtr ai` and `gtr new --ai` now run `postCd` hooks before launching the AI process, so env vars set by hooks (e.g., `source ./vars.sh`) propagate to the AI tool
- Adds `run_hooks_export` to `lib/hooks.sh` — a hook runner that `eval`s without subshell isolation, so `export` calls persist. Call sites wrap it in an explicit `( ... )` subshell for `set -e` safety
- Hook failures warn and continue — they never block the AI launch

Closes #144

## Test plan

- [x] 330 BATS tests pass (6 new for `run_hooks_export`)
- [x] Manual: `gtr ai` with postCd hook → env var propagates to AI process
- [x] Manual: failing hook warns but AI still launches
- [x] Manual: no postCd hooks configured → no extra output, clean launch
- [x] ShellCheck clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * AI tool auto-launch now supplies repository context (root path, branch information) when initiated after worktree creation.

* **Tests**
  * Added test coverage for hook execution with environment variable propagation and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->