### PR TITLE
fix(core): resolve --from ref to SHA to prevent git DWIM overriding branch name

### DIFF
--- a/lib/core.sh
+++ b/lib/core.sh
@@ -449,8 +449,8 @@ create_worktree() {
   # from overriding the -b flag when from_ref matches a remote branch name.
   # Try the ref as-is first, then with origin/ prefix for remote-only refs.
   local resolved_ref
-  resolved_ref=$(git rev-parse --verify "$from_ref" 2>/dev/null) \
-    || resolved_ref=$(git rev-parse --verify "origin/$from_ref" 2>/dev/null) \
+  resolved_ref=$(git rev-parse --verify "${from_ref}^{commit}" 2>/dev/null) \
+    || resolved_ref=$(git rev-parse --verify "origin/${from_ref}^{commit}" 2>/dev/null) \
     || resolved_ref="$from_ref"
 
   case "$track_mode" in

--- a/tests/core_create_worktree.bats
+++ b/tests/core_create_worktree.bats
@@ -159,7 +159,7 @@ teardown() {
   [ "$actual_sha" = "$expected_sha" ]
 }
 
-@test "create_worktree from tag starts at the tagged commit" {
+@test "create_worktree from lightweight tag starts at the tagged commit" {
   git commit --allow-empty -m "tagged commit" --quiet
   local expected_sha
   expected_sha=$(git rev-parse HEAD)
@@ -168,7 +168,24 @@ teardown() {
   git commit --allow-empty -m "after tag" --quiet
 
   local wt_path
-  wt_path=$(create_worktree "$TEST_WORKTREES_DIR" "" "from-tag" "v1.0.0" "none" "1")
+  wt_path=$(create_worktree "$TEST_WORKTREES_DIR" "" "from-light-tag" "v1.0.0" "none" "1")
+  [ -d "$wt_path" ]
+
+  local actual_sha
+  actual_sha=$(git -C "$wt_path" rev-parse HEAD)
+  [ "$actual_sha" = "$expected_sha" ]
+}
+
+@test "create_worktree from annotated tag starts at the tagged commit" {
+  git commit --allow-empty -m "tagged commit" --quiet
+  local expected_sha
+  expected_sha=$(git rev-parse HEAD)
+  git tag -a v2.0.0 -m "v2.0.0"
+
+  git commit --allow-empty -m "after tag" --quiet
+
+  local wt_path
+  wt_path=$(create_worktree "$TEST_WORKTREES_DIR" "" "from-ann-tag" "v2.0.0" "none" "1")
   [ -d "$wt_path" ]
 
   local actual_sha


### PR DESCRIPTION
## Summary

- When `--from <ref>` matches a remote tracking branch name, git's guess-remote logic overrides the explicit `-b` flag and creates a tracking branch with the remote name instead of the requested name
- Fix resolves `from_ref` to a commit SHA before passing it to `git worktree add -b`, preventing git from matching it to a remote branch
- Uses `git rev-parse --verify` with an `origin/` fallback, compatible with all supported git versions (2.17+)

Closes #146

## Test plan

- [x] All 330 existing BATS tests pass (same 9 pre-existing failures unrelated to this change)
- [x] 7 new tests added covering all `--from` ref types:
  - `--from <local-branch>` — resolves to correct commit
  - `--from <tag>` — resolves to tagged commit
  - `--from <commit-sha>` — passes through correctly
  - `--from <remote-branch-name>` — uses requested branch name, not remote name (the bug)
  - `--from <remote-branch-name>` — starts at correct commit
  - `--from` with auto track mode — honours from_ref
  - `--from <invalid-ref>` — fails with error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve worktree creation so branch references are reliably resolved to the intended commit, avoiding accidental selection of remote branches when names overlap.

* **Tests**
  * Expanded tests covering worktree creation from local branches, remote branches, tags, commit SHAs, auto mode behavior, and invalid-reference error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->