### PR TITLE
Secure shared .gtrconfig commands behind trust

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -4,13 +4,15 @@ on:
   release:
     types: [published]
 
+permissions: read-all
+
 jobs:
   homebrew:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3
         with:
           formula-name: git-gtr
           formula-path: Formula/git-gtr.rb

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,12 +6,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -24,7 +26,7 @@ jobs:
     name: Completions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Verify completion files are up to date
         run: ./scripts/generate-completions.sh --check
@@ -33,7 +35,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install BATS
         run: sudo apt-get update && sudo apt-get install -y bats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 
+### Added
+
+- `git gtr trust` now covers `.gtrconfig` `defaults.editor` and `defaults.ai` entries as executable commands, preventing shared config from selecting editor or AI commands until reviewed.
+
 ## [2.7.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Review and approve hook commands defined in the repository's `.gtrconfig` file. 
 git gtr trust                              # Review and approve .gtrconfig hooks
 ```
 
-Trust is stored per content hash and must be re-approved if hooks change. Hooks from your local git config (`.git/config`, `~/.gitconfig`) are always trusted.
+Trust is stored per repository path plus hook definitions and must be re-approved if hooks change. Hooks from your local git config (`.git/config`, `~/.gitconfig`) are always trusted.
 
 ### Other Commands
 
@@ -368,6 +368,14 @@ git gtr config set gtr.editor.default cursor
 
 # Set your AI tool (aider, auggie, claude, codex, continue, copilot, cursor, gemini, opencode)
 git gtr config set gtr.ai.default claude
+
+# Override-backed adapters may include flags
+git gtr config set gtr.editor.default "nano -w"
+git gtr config set gtr.ai.default "claude --continue"
+
+# Generic fallbacks may use other safe PATH commands
+git gtr config set gtr.editor.default "code --wait"
+git gtr config set gtr.ai.default "bunx @github/copilot@latest"
 
 # Copy env files to new worktrees
 git gtr config add gtr.copy.include "**/.env.example"
@@ -401,6 +409,8 @@ git gtr config set gtr.ui.color never
 ```
 
 **Hook trust:** Hooks defined in `.gtrconfig` require explicit approval before they execute. Run `git gtr trust` after cloning a repository or when `.gtrconfig` hooks change. This protects against malicious hook injection in shared repositories.
+
+**Adapter safety:** Generic `gtr.editor.default` and `gtr.ai.default` values must resolve to safe PATH commands. Filesystem paths such as `./tool` and shell wrapper forms such as `sh -c ...` are rejected. Override-backed adapters like `claude`, `cursor`, and `nano` may include additional flags, for example `claude --continue` or `nano -w`.
 
 **Configuration precedence** (highest to lowest):
 

--- a/README.md
+++ b/README.md
@@ -345,13 +345,13 @@ git gtr clean --merged --force --yes           # Force-clean and auto-confirm
 
 ### `git gtr trust`
 
-Review and approve hook commands defined in the repository's `.gtrconfig` file. Hooks from `.gtrconfig` are **not executed** until explicitly trusted — this prevents malicious contributors from injecting arbitrary shell commands via shared config files.
+Review and approve executable commands defined in the repository's `.gtrconfig` file. Hooks and editor/AI defaults from `.gtrconfig` are **not used** until explicitly trusted — this prevents malicious contributors from injecting arbitrary shell commands via shared config files.
 
 ```bash
-git gtr trust                              # Review and approve .gtrconfig hooks
+git gtr trust                              # Review and approve .gtrconfig commands
 ```
 
-Trust is stored per repository path plus hook definitions and must be re-approved if hooks change. Hooks from your local git config (`.git/config`, `~/.gitconfig`) are always trusted.
+Trust is stored per repository path plus executable command definitions and must be re-approved if hooks or editor/AI defaults change. Hooks and defaults from your local git config (`.git/config`, `~/.gitconfig`) are always trusted.
 
 ### Other Commands
 
@@ -412,14 +412,14 @@ git gtr config set gtr.ui.color never
     remote = upstream
 ```
 
-**Hook trust:** Hooks defined in `.gtrconfig` require explicit approval before they execute. Run `git gtr trust` after cloning a repository or when `.gtrconfig` hooks change. This protects against malicious hook injection in shared repositories.
+**Command trust:** Hooks and editor/AI defaults defined in `.gtrconfig` require explicit approval before they execute or select tools. Run `git gtr trust` after cloning a repository or when `.gtrconfig` command entries change. This protects against malicious command injection in shared repositories.
 
 **Adapter safety:** Generic `gtr.editor.default` and `gtr.ai.default` values must resolve to safe PATH commands. Filesystem paths such as `./tool` and shell wrapper forms such as `sh -c ...` are rejected. Override-backed adapters like `claude`, `cursor`, and `nano` may include additional flags, for example `claude --continue` or `nano -w`.
 
 **Configuration precedence** (highest to lowest):
 
 1. `git config --local` (`.git/config`) - personal overrides
-2. `.gtrconfig` (repo root) - team defaults (hooks require `git gtr trust`)
+2. `.gtrconfig` (repo root) - team defaults (hooks and editor/AI defaults require `git gtr trust`)
 3. `git config --global` (`~/.gitconfig`) - user defaults
 
 > For complete configuration reference including all settings, hooks, file copying patterns, and environment variables, see [docs/configuration.md](docs/configuration.md)

--- a/README.md
+++ b/README.md
@@ -340,6 +340,16 @@ git gtr clean --merged --force --yes           # Force-clean and auto-confirm
 
 **Note:** The `--merged` mode auto-detects your hosting provider (GitHub or GitLab) from the `origin` remote URL and requires the corresponding CLI tool (`gh` or `glab`) to be installed and authenticated. For self-hosted instances, set the provider explicitly: `git gtr config set gtr.provider gitlab`.
 
+### `git gtr trust`
+
+Review and approve hook commands defined in the repository's `.gtrconfig` file. Hooks from `.gtrconfig` are **not executed** until explicitly trusted — this prevents malicious contributors from injecting arbitrary shell commands via shared config files.
+
+```bash
+git gtr trust                              # Review and approve .gtrconfig hooks
+```
+
+Trust is stored per content hash and must be re-approved if hooks change. Hooks from your local git config (`.git/config`, `~/.gitconfig`) are always trusted.
+
 ### Other Commands
 
 - `git gtr doctor` - Health check (verify git, editors, AI tools)
@@ -390,10 +400,12 @@ git gtr config set gtr.ui.color never
     ai = claude
 ```
 
+**Hook trust:** Hooks defined in `.gtrconfig` require explicit approval before they execute. Run `git gtr trust` after cloning a repository or when `.gtrconfig` hooks change. This protects against malicious hook injection in shared repositories.
+
 **Configuration precedence** (highest to lowest):
 
 1. `git config --local` (`.git/config`) - personal overrides
-2. `.gtrconfig` (repo root) - team defaults
+2. `.gtrconfig` (repo root) - team defaults (hooks require `git gtr trust`)
 3. `git config --global` (`~/.gitconfig`) - user defaults
 
 > For complete configuration reference including all settings, hooks, file copying patterns, and environment variables, see [docs/configuration.md](docs/configuration.md)

--- a/adapters/ai/claude.sh
+++ b/adapters/ai/claude.sh
@@ -42,6 +42,7 @@ ai_can_start() {
 ai_start() {
   local path="$1"
   shift
+  local configured_args=("${GTR_AI_CMD_ARGS[@]}")
 
   local claude_cmd
   claude_cmd="$(find_claude_executable)"
@@ -57,5 +58,5 @@ ai_start() {
     return 1
   fi
 
-  (cd "$path" && "$claude_cmd" "$@")
+  (cd "$path" && "$claude_cmd" "${configured_args[@]}" "$@")
 }

--- a/adapters/ai/cursor.sh
+++ b/adapters/ai/cursor.sh
@@ -11,6 +11,7 @@ ai_can_start() {
 ai_start() {
   local path="$1"
   shift
+  local configured_args=("${GTR_AI_CMD_ARGS[@]}")
 
   if ! ai_can_start; then
     log_error "Cursor not found. Install from https://cursor.com"
@@ -25,9 +26,9 @@ ai_start() {
 
   # Try cursor-agent first, then fallback to cursor CLI commands
   if command -v cursor-agent >/dev/null 2>&1; then
-    (cd "$path" && cursor-agent "$@")
+    (cd "$path" && cursor-agent "${configured_args[@]}" "$@")
   elif command -v cursor >/dev/null 2>&1; then
     # Try various Cursor CLI patterns (implementation varies by version)
-    (cd "$path" && cursor cli "$@") 2>/dev/null || (cd "$path" && cursor "$@")
+    (cd "$path" && cursor cli "${configured_args[@]}" "$@") 2>/dev/null || (cd "$path" && cursor "${configured_args[@]}" "$@")
   fi
 }

--- a/adapters/editor/nano.sh
+++ b/adapters/editor/nano.sh
@@ -10,10 +10,16 @@ editor_can_open() {
 # Usage: editor_open path
 editor_open() {
   local path="$1"
+  local configured_args=("${GTR_EDITOR_CMD_ARGS[@]}")
 
   if ! editor_can_open; then
     log_error "Nano not found. Usually pre-installed on Unix systems."
     return 1
+  fi
+
+  if [ "${#configured_args[@]}" -gt 0 ]; then
+    (cd "$path" && nano "${configured_args[@]}")
+    return $?
   fi
 
   # Open nano in the directory (just cd there, nano doesn't open directories)

--- a/bin/git-gtr
+++ b/bin/git-gtr
@@ -100,6 +100,9 @@ main() {
     init)
       cmd_init "$@"
       ;;
+    trust)
+      cmd_trust "$@"
+      ;;
     version|--version|-v)
       echo "git gtr version $GTR_VERSION"
       ;;

--- a/completions/_git-gtr
+++ b/completions/_git-gtr
@@ -45,6 +45,7 @@ _git-gtr() {
     'config:Manage configuration'
     'completion:Generate shell completions'
     'init:Generate shell integration for cd support'
+    'trust:Trust .gtrconfig hooks'
     'version:Show version'
     'help:Show help'
   )

--- a/completions/_git-gtr
+++ b/completions/_git-gtr
@@ -45,7 +45,7 @@ _git-gtr() {
     'config:Manage configuration'
     'completion:Generate shell completions'
     'init:Generate shell integration for cd support'
-    'trust:Trust .gtrconfig hooks'
+    'trust:Trust .gtrconfig commands'
     'version:Show version'
     'help:Show help'
   )

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -54,7 +54,7 @@ complete -f -c git -n '__fish_git_gtr_using_command completion' -a 'bash zsh fis
 complete -f -c git -n '__fish_git_gtr_needs_command' -a init -d 'Generate shell integration for cd support'
 complete -f -c git -n '__fish_git_gtr_using_command init' -a 'bash zsh fish' -d 'Shell type'
 complete -c git -n '__fish_git_gtr_using_command init' -l as -d 'Custom function name' -r
-complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig hooks'
+complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig commands'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a version -d 'Show version'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a help -d 'Show help'
 

--- a/completions/git-gtr.fish
+++ b/completions/git-gtr.fish
@@ -54,6 +54,7 @@ complete -f -c git -n '__fish_git_gtr_using_command completion' -a 'bash zsh fis
 complete -f -c git -n '__fish_git_gtr_needs_command' -a init -d 'Generate shell integration for cd support'
 complete -f -c git -n '__fish_git_gtr_using_command init' -a 'bash zsh fish' -d 'Shell type'
 complete -c git -n '__fish_git_gtr_using_command init' -l as -d 'Custom function name' -r
+complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig hooks'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a version -d 'Show version'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a help -d 'Show help'
 

--- a/completions/gtr.bash
+++ b/completions/gtr.bash
@@ -25,7 +25,7 @@ _git_gtr() {
 
   # If we're completing the first argument after 'git gtr'
   if [ "$cword" -eq 2 ]; then
-    COMPREPLY=($(compgen -W "new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init help version" -- "$cur"))
+    COMPREPLY=($(compgen -W "new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init trust help version" -- "$cur"))
     return 0
   fi
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,6 +68,9 @@ Create a `.gtrconfig` file in your repository root to share configuration across
 > [!TIP]
 > See `templates/.gtrconfig.example` for a complete example with all available settings.
 
+> [!IMPORTANT]
+> Hooks and editor/AI defaults from `.gtrconfig` are executable command entries. They are ignored until you review them with `git gtr trust`; changing those entries requires re-approval.
+
 ---
 
 ## Worktree Settings

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -293,16 +293,6 @@ _parse_configured_command() {
   _set_array_var "$out_var" "${parsed_tokens[@]}"
 }
 
-_configured_command_uses_path_arg() {
-  local arg="$1"
-  case "$arg" in
-    /* | ./* | ../* | ~* | *\\*)
-      return 0
-      ;;
-  esac
-  return 1
-}
-
 _configured_command_is_wrapper() {
   local cmd_name="$1"
   case "$cmd_name" in
@@ -311,19 +301,6 @@ _configured_command_is_wrapper() {
       ;;
   esac
   return 1
-}
-
-# Reject raw shell syntax before argv parsing.
-_configured_command_has_safe_syntax() {
-  local command_string="$1"
-
-  # Reject shell metacharacters in config-supplied command names to prevent injection.
-  # shellcheck disable=SC2016 # Literal '$(' pattern match is intentional
-  case "$command_string" in
-    *\;* | *\`* | *'$('* | *\|* | *\&* | *'>'* | *'<'*)
-      return 1
-      ;;
-  esac
 }
 
 _configured_command_is_safe() {
@@ -342,12 +319,7 @@ _configured_command_is_safe() {
     return 1
   fi
 
-  local arg
-  for arg in "$@"; do
-    if _configured_command_uses_path_arg "$arg"; then
-      return 1
-    fi
-  done
+  return 0
 }
 
 # Run a config-supplied command argv that has already been parsed and validated.
@@ -469,8 +441,7 @@ resolve_workspace_file() {
 _load_adapter() {
   local type="$1" name="$2" label="$3" builtin_list="$4" path_hint="$5"
   local parsed_args=()
-  if ! _configured_command_has_safe_syntax "$name" \
-    || ! _parse_configured_command parsed_args "$name" \
+  if ! _parse_configured_command parsed_args "$name" \
     || ! _configured_command_is_safe "${parsed_args[@]}"; then
     log_error "$label '$name' is not a safe executable command"
     log_info "Use a PATH command name, optionally with flags (e.g., 'code --wait')"

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -166,10 +166,7 @@ editor_open() {
     target="$workspace"
   fi
 
-  # Split multi-word commands (e.g., "code --wait") into an array for safe execution
-  local _cmd_arr
-  read -ra _cmd_arr <<< "$GTR_EDITOR_CMD"
-  "${_cmd_arr[@]}" "$target"
+  _run_configured_command "$GTR_EDITOR_CMD" "$target"
 }
 
 # Globals set by load_ai_adapter: GTR_AI_CMD, GTR_AI_CMD_NAME
@@ -180,10 +177,20 @@ ai_can_start() {
 ai_start() {
   local path="$1"
   shift
-  # Split multi-word commands (e.g., "bunx @github/copilot@latest") into an array for safe execution
-  local _cmd_arr
-  read -ra _cmd_arr <<< "$GTR_AI_CMD"
-  (cd "$path" && "${_cmd_arr[@]}" "$@")
+  (cd "$path" && _run_configured_command "$GTR_AI_CMD" "$@")
+}
+
+# Parse and run a config-supplied command string while preserving quoted args.
+_run_configured_command() {
+  local command_string="$1"
+  shift
+  local extra_args=("$@")
+
+  (
+    eval "set -- $command_string" || exit 1
+    [ "$#" -gt 0 ] || exit 1
+    "$@" "${extra_args[@]}"
+  )
 }
 
 # Standard AI adapter builder — used by adapter files that follow the common pattern
@@ -297,23 +304,21 @@ resolve_workspace_file() {
 # Usage: _load_adapter <type> <name> <label> <builtin_list> <path_hint>
 _load_adapter() {
   local type="$1" name="$2" label="$3" builtin_list="$4" path_hint="$5"
+  local adapter_selector="${name%% *}"
 
-  # Reject adapter names containing path traversal characters
-  case "$name" in
-    */* | *..* | *\\*)
-      log_error "$label name '$name' contains invalid characters"
-      return 1
-      ;;
-  esac
-
-  local adapter_file="$GTR_DIR/adapters/${type}/${name}.sh"
+  local adapter_file="$GTR_DIR/adapters/${type}/${adapter_selector}.sh"
 
   # 1. Try loading explicit adapter file (custom overrides like claude, nano)
-  if [ -f "$adapter_file" ]; then
-    # shellcheck disable=SC1090
-    . "$adapter_file"
-    return 0
-  fi
+  case "$adapter_selector" in
+    */* | *..* | *\\*) ;;
+    *)
+      if [ -f "$adapter_file" ]; then
+        # shellcheck disable=SC1090
+        . "$adapter_file"
+        return 0
+      fi
+      ;;
+  esac
 
   # 2. Try registry lookup (declarative adapters)
   local registry entry

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -180,17 +180,161 @@ ai_start() {
   (cd "$path" && _run_configured_command "$GTR_AI_CMD" "$@")
 }
 
+# Split a config-supplied command string without shell evaluation.
+# Populates the global _GTR_PARSED_CMD_ARGS array.
+_parse_configured_command() {
+  local command_string="$1"
+  local length="${#command_string}"
+  local i=0 char="" token="" state="normal" escaped=0 token_started=0
+
+  _GTR_PARSED_CMD_ARGS=()
+
+  while [ "$i" -lt "$length" ]; do
+    char="${command_string:$i:1}"
+
+    case "$state" in
+      normal)
+        if [ "$escaped" -eq 1 ]; then
+          token="${token}${char}"
+          token_started=1
+          escaped=0
+        else
+          case "$char" in
+            "\\")
+              escaped=1
+              token_started=1
+              ;;
+            " " | $'\t' | $'\n')
+              if [ "$token_started" -eq 1 ]; then
+                _GTR_PARSED_CMD_ARGS+=("$token")
+                token=""
+                token_started=0
+              fi
+              ;;
+            "'")
+              state="single"
+              token_started=1
+              ;;
+            '"')
+              state="double"
+              token_started=1
+              ;;
+            *)
+              token="${token}${char}"
+              token_started=1
+              ;;
+          esac
+        fi
+        ;;
+      single)
+        if [ "$char" = "'" ]; then
+          state="normal"
+        else
+          token="${token}${char}"
+        fi
+        ;;
+      double)
+        if [ "$escaped" -eq 1 ]; then
+          token="${token}${char}"
+          token_started=1
+          escaped=0
+        else
+          case "$char" in
+            "\\")
+              escaped=1
+              token_started=1
+              ;;
+            '"')
+              state="normal"
+              ;;
+            *)
+              token="${token}${char}"
+              token_started=1
+              ;;
+          esac
+        fi
+        ;;
+    esac
+
+    i=$((i + 1))
+  done
+
+  [ "$escaped" -eq 0 ] || return 1
+  [ "$state" = "normal" ] || return 1
+
+  if [ "$token_started" -eq 1 ]; then
+    _GTR_PARSED_CMD_ARGS+=("$token")
+  fi
+
+  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ]
+}
+
+_configured_command_uses_path_arg() {
+  local arg="$1"
+  case "$arg" in
+    /* | ./* | ../* | ~* | *\\*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+_configured_command_is_wrapper() {
+  local cmd_name="$1"
+  case "$cmd_name" in
+    sh | bash | zsh | dash | ksh | fish | env | eval | source | . | python | python3 | node | ruby | perl | php | lua | pwsh | powershell)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+_validate_configured_command() {
+  local command_string="$1"
+
+  # Reject shell metacharacters in config-supplied command names to prevent injection.
+  # shellcheck disable=SC2016 # Literal '$(' pattern match is intentional
+  case "$command_string" in
+    *\;* | *\`* | *'$('* | *\|* | *\&* | *'>'* | *'<'*)
+      return 1
+      ;;
+  esac
+
+  _parse_configured_command "$command_string" || return 1
+  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ] || return 1
+
+  local cmd_name="${_GTR_PARSED_CMD_ARGS[0]}"
+
+  case "$cmd_name" in
+    */* | *\\*)
+      return 1
+      ;;
+  esac
+
+  if _configured_command_is_wrapper "$cmd_name" && [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 1 ]; then
+    return 1
+  fi
+
+  local arg
+  for arg in "${_GTR_PARSED_CMD_ARGS[@]:1}"; do
+    if _configured_command_uses_path_arg "$arg"; then
+      return 1
+    fi
+  done
+
+  type -P "$cmd_name" >/dev/null 2>&1
+}
+
 # Parse and run a config-supplied command string while preserving quoted args.
 _run_configured_command() {
   local command_string="$1"
   shift
   local extra_args=("$@")
 
-  (
-    eval "set -- $command_string" || exit 1
-    [ "$#" -gt 0 ] || exit 1
-    "$@" "${extra_args[@]}"
-  )
+  _parse_configured_command "$command_string" || return 1
+  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ] || return 1
+
+  "${_GTR_PARSED_CMD_ARGS[@]}" "${extra_args[@]}"
 }
 
 # Standard AI adapter builder — used by adapter files that follow the common pattern
@@ -304,7 +448,14 @@ resolve_workspace_file() {
 # Usage: _load_adapter <type> <name> <label> <builtin_list> <path_hint>
 _load_adapter() {
   local type="$1" name="$2" label="$3" builtin_list="$4" path_hint="$5"
-  local adapter_selector="${name%% *}"
+  if ! _validate_configured_command "$name"; then
+    log_error "$label '$name' is not a safe executable command"
+    log_info "Use a PATH command name, optionally with flags (e.g., 'code --wait')"
+    return 1
+  fi
+
+  local adapter_selector="${_GTR_PARSED_CMD_ARGS[0]}"
+  local cmd_args=("${_GTR_PARSED_CMD_ARGS[@]:1}")
 
   local adapter_file="$GTR_DIR/adapters/${type}/${adapter_selector}.sh"
 
@@ -313,6 +464,17 @@ _load_adapter() {
     */* | *..* | *\\*) ;;
     *)
       if [ -f "$adapter_file" ]; then
+        if [ "$type" = "editor" ]; then
+          # shellcheck disable=SC2034 # Used by sourced override adapters.
+          GTR_EDITOR_CMD="$name"
+          GTR_EDITOR_CMD_NAME="$adapter_selector"
+          GTR_EDITOR_CMD_ARGS=("${cmd_args[@]}")
+        else
+          # shellcheck disable=SC2034 # Used by sourced override adapters.
+          GTR_AI_CMD="$name"
+          GTR_AI_CMD_NAME="$adapter_selector"
+          GTR_AI_CMD_ARGS=("${cmd_args[@]}")
+        fi
         # shellcheck disable=SC1090
         . "$adapter_file"
         return 0
@@ -337,44 +499,27 @@ _load_adapter() {
     return 0
   fi
 
-  # 3. Generic fallback: check if command exists in PATH
-  # Extract first word (command name) from potentially multi-word string
-  local cmd_name="${name%% *}"
-
-  case "$cmd_name" in
-    */* | *\\*)
-      log_error "$label '$name' must use a PATH command name, not a filesystem path"
-      log_info "Use a simple command name, optionally with flags (e.g., 'code --wait')"
-      return 1
-      ;;
-  esac
-
-  if ! command -v "$cmd_name" >/dev/null 2>&1; then
+  # 3. Generic fallback: command already validated and resolved in PATH
+  local cmd_name="$adapter_selector"
+  if ! type -P "$cmd_name" >/dev/null 2>&1; then
     log_error "$label '$name' not found"
     log_info "Built-in adapters: $builtin_list"
     log_info "Or use any $label command available in your PATH (e.g., $path_hint)"
     return 1
   fi
 
-  # Reject shell metacharacters in config-supplied command names to prevent injection
-  # Allows multi-word commands (e.g., "code --wait") but blocks shell operators
-  # shellcheck disable=SC2016 # Literal '$(' pattern match is intentional
-  case "$name" in
-    *\;* | *\`* | *'$('* | *\|* | *\&* | *'>'* | *'<'*)
-      log_error "$label '$name' contains shell metacharacters — refusing to execute"
-      log_info "Use a simple command name, optionally with flags (e.g., 'code --wait')"
-      return 1
-      ;;
-  esac
-
   # Set globals for generic adapter functions
   # Note: $name may contain arguments (e.g., "code --wait", "bunx @github/copilot@latest")
   if [ "$type" = "editor" ]; then
     GTR_EDITOR_CMD="$name"
     GTR_EDITOR_CMD_NAME="$cmd_name"
+    # shellcheck disable=SC2034 # Used by sourced override adapters.
+    GTR_EDITOR_CMD_ARGS=("${cmd_args[@]}")
   else
     GTR_AI_CMD="$name"
     GTR_AI_CMD_NAME="$cmd_name"
+    # shellcheck disable=SC2034 # Used by sourced override adapters.
+    GTR_AI_CMD_ARGS=("${cmd_args[@]}")
   fi
 }
 

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -150,7 +150,8 @@ EOF
 
 # Generic adapter functions (used when no explicit adapter file exists)
 # These will be overridden if an adapter file is sourced
-# Globals set by load_editor_adapter: GTR_EDITOR_CMD, GTR_EDITOR_CMD_NAME
+# Globals set by load_editor_adapter:
+#   GTR_EDITOR_CMD, GTR_EDITOR_CMD_NAME, GTR_EDITOR_CMD_ARGS
 editor_can_open() {
   command -v "$GTR_EDITOR_CMD_NAME" >/dev/null 2>&1
 }
@@ -166,10 +167,11 @@ editor_open() {
     target="$workspace"
   fi
 
-  _run_configured_command "$GTR_EDITOR_CMD" "$target"
+  _run_configured_command "$GTR_EDITOR_CMD_NAME" "${GTR_EDITOR_CMD_ARGS[@]}" "$target"
 }
 
-# Globals set by load_ai_adapter: GTR_AI_CMD, GTR_AI_CMD_NAME
+# Globals set by load_ai_adapter:
+#   GTR_AI_CMD, GTR_AI_CMD_NAME, GTR_AI_CMD_ARGS
 ai_can_start() {
   command -v "$GTR_AI_CMD_NAME" >/dev/null 2>&1
 }
@@ -177,17 +179,38 @@ ai_can_start() {
 ai_start() {
   local path="$1"
   shift
-  (cd "$path" && _run_configured_command "$GTR_AI_CMD" "$@")
+  (cd "$path" && _run_configured_command "$GTR_AI_CMD_NAME" "${GTR_AI_CMD_ARGS[@]}" "$@")
+}
+
+# Assign an array to a caller-provided variable name.
+# Bash 3.2 has no namerefs, so this uses a safely quoted eval assignment.
+_set_array_var() {
+  local var_name="$1"
+  shift
+
+  case "$var_name" in
+    [a-zA-Z_][a-zA-Z0-9_]*) ;;
+    *) return 1 ;;
+  esac
+
+  local assignment="${var_name}=("
+  local item
+  for item in "$@"; do
+    assignment="${assignment}$(printf '%q ' "$item")"
+  done
+  assignment="${assignment})"
+
+  eval "$assignment"
 }
 
 # Split a config-supplied command string without shell evaluation.
-# Populates the global _GTR_PARSED_CMD_ARGS array.
+# Usage: _parse_configured_command <out_array_name> <command_string>
 _parse_configured_command() {
-  local command_string="$1"
+  local out_var="$1"
+  local command_string="$2"
   local length="${#command_string}"
   local i=0 char="" token="" state="normal" escaped=0 token_started=0
-
-  _GTR_PARSED_CMD_ARGS=()
+  local parsed_tokens=()
 
   while [ "$i" -lt "$length" ]; do
     char="${command_string:$i:1}"
@@ -206,7 +229,7 @@ _parse_configured_command() {
               ;;
             " " | $'\t' | $'\n')
               if [ "$token_started" -eq 1 ]; then
-                _GTR_PARSED_CMD_ARGS+=("$token")
+                parsed_tokens+=("$token")
                 token=""
                 token_started=0
               fi
@@ -263,10 +286,11 @@ _parse_configured_command() {
   [ "$state" = "normal" ] || return 1
 
   if [ "$token_started" -eq 1 ]; then
-    _GTR_PARSED_CMD_ARGS+=("$token")
+    parsed_tokens+=("$token")
   fi
 
-  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ]
+  [ "${#parsed_tokens[@]}" -gt 0 ] || return 1
+  _set_array_var "$out_var" "${parsed_tokens[@]}"
 }
 
 _configured_command_uses_path_arg() {
@@ -289,7 +313,8 @@ _configured_command_is_wrapper() {
   return 1
 }
 
-_validate_configured_command() {
+# Reject raw shell syntax before argv parsing.
+_configured_command_has_safe_syntax() {
   local command_string="$1"
 
   # Reject shell metacharacters in config-supplied command names to prevent injection.
@@ -299,11 +324,13 @@ _validate_configured_command() {
       return 1
       ;;
   esac
+}
 
-  _parse_configured_command "$command_string" || return 1
-  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ] || return 1
+_configured_command_is_safe() {
+  [ "$#" -gt 0 ] || return 1
 
-  local cmd_name="${_GTR_PARSED_CMD_ARGS[0]}"
+  local cmd_name="$1"
+  shift
 
   case "$cmd_name" in
     */* | *\\*)
@@ -311,28 +338,23 @@ _validate_configured_command() {
       ;;
   esac
 
-  if _configured_command_is_wrapper "$cmd_name" && [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 1 ]; then
+  if _configured_command_is_wrapper "$cmd_name" && [ "$#" -gt 0 ]; then
     return 1
   fi
 
   local arg
-  for arg in "${_GTR_PARSED_CMD_ARGS[@]:1}"; do
+  for arg in "$@"; do
     if _configured_command_uses_path_arg "$arg"; then
       return 1
     fi
   done
 }
 
-# Parse and run a config-supplied command string while preserving quoted args.
+# Run a config-supplied command argv that has already been parsed and validated.
+# Usage: _run_configured_command <argv...>
 _run_configured_command() {
-  local command_string="$1"
-  shift
-  local extra_args=("$@")
-
-  _parse_configured_command "$command_string" || return 1
-  [ "${#_GTR_PARSED_CMD_ARGS[@]}" -gt 0 ] || return 1
-
-  "${_GTR_PARSED_CMD_ARGS[@]}" "${extra_args[@]}"
+  [ "$#" -gt 0 ] || return 1
+  "$@"
 }
 
 # Standard AI adapter builder — used by adapter files that follow the common pattern
@@ -446,14 +468,17 @@ resolve_workspace_file() {
 # Usage: _load_adapter <type> <name> <label> <builtin_list> <path_hint>
 _load_adapter() {
   local type="$1" name="$2" label="$3" builtin_list="$4" path_hint="$5"
-  if ! _validate_configured_command "$name"; then
+  local parsed_args=()
+  if ! _configured_command_has_safe_syntax "$name" \
+    || ! _parse_configured_command parsed_args "$name" \
+    || ! _configured_command_is_safe "${parsed_args[@]}"; then
     log_error "$label '$name' is not a safe executable command"
     log_info "Use a PATH command name, optionally with flags (e.g., 'code --wait')"
     return 1
   fi
 
-  local adapter_selector="${_GTR_PARSED_CMD_ARGS[0]}"
-  local cmd_args=("${_GTR_PARSED_CMD_ARGS[@]:1}")
+  local adapter_selector="${parsed_args[0]}"
+  local cmd_args=("${parsed_args[@]:1}")
 
   local adapter_file="$GTR_DIR/adapters/${type}/${adapter_selector}.sh"
 
@@ -509,11 +534,13 @@ _load_adapter() {
   # Set globals for generic adapter functions
   # Note: $name may contain arguments (e.g., "code --wait", "bunx @github/copilot@latest")
   if [ "$type" = "editor" ]; then
+    # shellcheck disable=SC2034 # Exposed for adapter state/introspection.
     GTR_EDITOR_CMD="$name"
     GTR_EDITOR_CMD_NAME="$cmd_name"
     # shellcheck disable=SC2034 # Used by sourced override adapters.
     GTR_EDITOR_CMD_ARGS=("${cmd_args[@]}")
   else
+    # shellcheck disable=SC2034 # Exposed for adapter state/introspection.
     GTR_AI_CMD="$name"
     GTR_AI_CMD_NAME="$cmd_name"
     # shellcheck disable=SC2034 # Used by sourced override adapters.

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -341,6 +341,14 @@ _load_adapter() {
   # Extract first word (command name) from potentially multi-word string
   local cmd_name="${name%% *}"
 
+  case "$cmd_name" in
+    */* | *\\*)
+      log_error "$label '$name' must use a PATH command name, not a filesystem path"
+      log_info "Use a simple command name, optionally with flags (e.g., 'code --wait')"
+      return 1
+      ;;
+  esac
+
   if ! command -v "$cmd_name" >/dev/null 2>&1; then
     log_error "$label '$name' not found"
     log_info "Built-in adapters: $builtin_list"

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -321,8 +321,6 @@ _validate_configured_command() {
       return 1
     fi
   done
-
-  type -P "$cmd_name" >/dev/null 2>&1
 }
 
 # Parse and run a config-supplied command string while preserving quoted args.

--- a/lib/adapters.sh
+++ b/lib/adapters.sh
@@ -166,9 +166,10 @@ editor_open() {
     target="$workspace"
   fi
 
-  # $GTR_EDITOR_CMD may contain arguments (e.g., "code --wait")
-  # Using eval here is necessary to handle multi-word commands properly
-  eval "$GTR_EDITOR_CMD \"\$target\""
+  # Split multi-word commands (e.g., "code --wait") into an array for safe execution
+  local _cmd_arr
+  read -ra _cmd_arr <<< "$GTR_EDITOR_CMD"
+  "${_cmd_arr[@]}" "$target"
 }
 
 # Globals set by load_ai_adapter: GTR_AI_CMD, GTR_AI_CMD_NAME
@@ -179,9 +180,10 @@ ai_can_start() {
 ai_start() {
   local path="$1"
   shift
-  # $GTR_AI_CMD may contain arguments (e.g., "bunx @github/copilot@latest")
-  # Using eval here is necessary to handle multi-word commands properly
-  (cd "$path" && eval "$GTR_AI_CMD \"\$@\"")
+  # Split multi-word commands (e.g., "bunx @github/copilot@latest") into an array for safe execution
+  local _cmd_arr
+  read -ra _cmd_arr <<< "$GTR_AI_CMD"
+  (cd "$path" && "${_cmd_arr[@]}" "$@")
 }
 
 # Standard AI adapter builder — used by adapter files that follow the common pattern
@@ -295,6 +297,15 @@ resolve_workspace_file() {
 # Usage: _load_adapter <type> <name> <label> <builtin_list> <path_hint>
 _load_adapter() {
   local type="$1" name="$2" label="$3" builtin_list="$4" path_hint="$5"
+
+  # Reject adapter names containing path traversal characters
+  case "$name" in
+    */* | *..* | *\\*)
+      log_error "$label name '$name' contains invalid characters"
+      return 1
+      ;;
+  esac
+
   local adapter_file="$GTR_DIR/adapters/${type}/${name}.sh"
 
   # 1. Try loading explicit adapter file (custom overrides like claude, nano)
@@ -331,6 +342,17 @@ _load_adapter() {
     log_info "Or use any $label command available in your PATH (e.g., $path_hint)"
     return 1
   fi
+
+  # Reject shell metacharacters in config-supplied command names to prevent injection
+  # Allows multi-word commands (e.g., "code --wait") but blocks shell operators
+  # shellcheck disable=SC2016 # Literal '$(' pattern match is intentional
+  case "$name" in
+    *\;* | *\`* | *'$('* | *\|* | *\&* | *'>'* | *'<'*)
+      log_error "$label '$name' contains shell metacharacters — refusing to execute"
+      log_info "Use a simple command name, optionally with flags (e.g., 'code --wait')"
+      return 1
+      ;;
+  esac
 
   # Set globals for generic adapter functions
   # Note: $name may contain arguments (e.g., "code --wait", "bunx @github/copilot@latest")

--- a/lib/args.sh
+++ b/lib/args.sh
@@ -39,15 +39,13 @@ _pa_match_flag() {
 
     # Check if $flag matches any alternative in the pattern
     local alt matched=0
-    local IFS_save="$IFS"
-    IFS="|"
+    local IFS="|"
     for alt in $line; do
       if [ "$flag" = "$alt" ]; then
         matched=1
         break
       fi
     done
-    IFS="$IFS_save"
 
     if [ "$matched" = "1" ]; then
       # Derive variable name from the first (canonical) pattern

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -57,11 +57,12 @@ Special:
 
 Available editors:
   antigravity, atom, cursor, emacs, idea, nano, nvim, pycharm, sublime, vim,
-  vscode, webstorm, zed, none (or any command in your PATH)
+  vscode, webstorm, zed, none (or any safe command in your PATH)
 
 Examples:
   git gtr editor my-feature                     # Uses default editor
   git gtr editor my-feature --editor vscode     # Override with vscode
+  git gtr editor my-feature --editor "nano -w"  # Override-backed adapter with flags
   git gtr editor 1                              # Open main repo
 EOF
 }
@@ -84,11 +85,12 @@ Special:
 
 Available AI tools:
   aider, auggie, claude, codex, continue, copilot, cursor, gemini,
-  opencode, none (or any command in your PATH)
+  opencode, none (or any safe command in your PATH)
 
 Examples:
   git gtr ai my-feature                         # Uses default AI tool
   git gtr ai my-feature --ai aider              # Override with aider
+  git gtr ai my-feature --ai "claude --continue"
   git gtr ai my-feature -- --verbose            # Pass args to AI tool
   git gtr ai 1                                  # AI in main repo
 EOF
@@ -255,9 +257,14 @@ Examples:
   git gtr config                                # List all config
   git gtr config list --local                   # List local config only
   git gtr config set gtr.editor.default cursor  # Set default editor
+  git gtr config set gtr.editor.default "code --wait"
   git gtr config add gtr.copy.include ".env*"   # Add copy pattern
   git gtr config get gtr.ai.default             # Get AI tool setting
   git gtr config unset gtr.worktrees.prefix     # Remove prefix setting
+
+Generic editor/AI defaults must be safe PATH commands. Filesystem paths
+such as ./tool and shell-wrapper forms such as sh -c ... are rejected.
+Override-backed adapters like claude, cursor, and nano may include flags.
 EOF
 }
 
@@ -283,8 +290,10 @@ git gtr adapter - List available adapters
 Usage: git gtr adapter
 
 Lists all built-in editor and AI tool adapters, along with their availability
-on the current system. Any command in your PATH can also be used as an
-editor or AI tool without a built-in adapter.
+on the current system. Safe PATH commands can also be used without a built-in
+adapter. Path-based commands like ./tool and shell wrappers like sh -c are
+rejected, while override-backed adapters such as claude, cursor, and nano may
+include flags.
 
 Examples:
   git gtr adapter                               # Show all adapters
@@ -411,8 +420,9 @@ Reviews and approves hook commands defined in the repository's .gtrconfig
 file. Hooks from .gtrconfig are not executed until explicitly trusted.
 
 This prevents malicious contributors from injecting arbitrary shell
-commands via shared .gtrconfig files. Trust is stored per content hash
-in ~/.config/gtr/trusted/ and must be re-approved if hooks change.
+commands via shared .gtrconfig files. Trust is stored per repository
+path plus hook definitions in ~/.config/gtr/trusted/ and must be
+re-approved if hooks change.
 
 Hooks from your local git config (.git/config, ~/.gitconfig) are always
 trusted since you control those files directly.
@@ -582,7 +592,7 @@ SETUP & MAINTENANCE:
 
   adapter
          List available editor & AI tool adapters
-         Note: Any command in your PATH can be used (e.g., code-insiders, bunx)
+         Note: Safe PATH commands can be used (e.g., code --wait, bunx @github/copilot@latest)
 
   clean [options]
          Remove stale/prunable worktrees and empty directories

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -415,23 +415,24 @@ EOF
 
 _help_trust() {
   cat <<'EOF'
-git gtr trust - Trust .gtrconfig hooks
+git gtr trust - Trust .gtrconfig commands
 
 Usage: git gtr trust
 
-Reviews and approves hook commands defined in the repository's .gtrconfig
-file. Hooks from .gtrconfig are not executed until explicitly trusted.
+Reviews and approves executable commands defined in the repository's
+.gtrconfig file. Hooks and editor/AI defaults from .gtrconfig are not
+used until explicitly trusted.
 
 This prevents malicious contributors from injecting arbitrary shell
 commands via shared .gtrconfig files. Trust is stored per repository
-path plus hook definitions in ~/.config/gtr/trusted/ and must be
-re-approved if hooks change.
+path plus executable command definitions in ~/.config/gtr/trusted/ and
+must be re-approved if those commands change.
 
-Hooks from your local git config (.git/config, ~/.gitconfig) are always
-trusted since you control those files directly.
+Hooks and defaults from your local git config (.git/config, ~/.gitconfig)
+are always trusted since you control those files directly.
 
 Examples:
-  git gtr trust                                 # Review and approve hooks
+  git gtr trust                                 # Review and approve commands
 EOF
 }
 
@@ -609,9 +610,9 @@ SETUP & MAINTENANCE:
          --force, -f: force removal even if worktree has uncommitted changes or untracked files
 
   trust
-         Review and approve .gtrconfig hook commands
-         Hooks from .gtrconfig are not executed until trusted
-         Trust is re-required when hook content changes
+         Review and approve .gtrconfig executable commands
+         Hooks and editor/AI defaults from .gtrconfig are not used until trusted
+         Trust is re-required when executable command entries change
 
   completion <shell>
          Generate shell completions (bash, zsh, fish)

--- a/lib/commands/help.sh
+++ b/lib/commands/help.sh
@@ -401,6 +401,27 @@ Command palette (gtr cd with no arguments, requires fzf):
 EOF
 }
 
+_help_trust() {
+  cat <<'EOF'
+git gtr trust - Trust .gtrconfig hooks
+
+Usage: git gtr trust
+
+Reviews and approves hook commands defined in the repository's .gtrconfig
+file. Hooks from .gtrconfig are not executed until explicitly trusted.
+
+This prevents malicious contributors from injecting arbitrary shell
+commands via shared .gtrconfig files. Trust is stored per content hash
+in ~/.config/gtr/trusted/ and must be re-approved if hooks change.
+
+Hooks from your local git config (.git/config, ~/.gitconfig) are always
+trusted since you control those files directly.
+
+Examples:
+  git gtr trust                                 # Review and approve hooks
+EOF
+}
+
 _help_version() {
   cat <<'EOF'
 git gtr version - Show version
@@ -571,6 +592,11 @@ SETUP & MAINTENANCE:
          --yes, -y: skip confirmation prompts
          --dry-run, -n: show what would be removed without removing
          --force, -f: force removal even if worktree has uncommitted changes or untracked files
+
+  trust
+         Review and approve .gtrconfig hook commands
+         Hooks from .gtrconfig are not executed until trusted
+         Trust is re-required when hook content changes
 
   completion <shell>
          Generate shell completions (bash, zsh, fish)

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -68,7 +68,7 @@ cmd_init() {
   # Generate output (cached to ~/.cache/gtr/, auto-invalidates on shell integration changes)
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gtr"
   local cache_file="$cache_dir/init-${func_name}.${shell}"
-  local cache_schema="${GTR_INIT_CACHE_VERSION:-2}"
+  local cache_schema="${GTR_INIT_CACHE_VERSION:-3}"
   local cache_stamp="# gtr-cache: version=${GTR_VERSION:-unknown} init=${cache_schema} func=$func_name shell=$shell"
 
   # Return cached output if version matches
@@ -115,6 +115,14 @@ __FUNC___hooks_hash() {
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 }
 
+__FUNC___hooks_trust_key() {
+  local _gtr_config_file="$1"
+  local _gtr_hook_hash _gtr_repo_root
+  _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || return 1
+  _gtr_repo_root="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)" || return 1
+  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
+}
+
 __FUNC___run_post_cd_hooks() {
   local dir="$1"
   local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
@@ -132,9 +140,9 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        local _gtr_hook_hash
-        _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || true
-        if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
+        local _gtr_trust_key
+        _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || true
+        if [ -n "$_gtr_trust_key" ] && [ -f "$_gtr_trust_dir/$_gtr_trust_key" ]; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -321,6 +329,15 @@ __FUNC___hooks_hash() {
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 }
 
+__FUNC___hooks_trust_key() {
+  emulate -L zsh
+  local _gtr_config_file="$1"
+  local _gtr_hook_hash _gtr_repo_root
+  _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || return 1
+  _gtr_repo_root="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)" || return 1
+  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
+}
+
 __FUNC___run_post_cd_hooks() {
   emulate -L zsh
   local dir="$1"
@@ -339,9 +356,9 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        local _gtr_hook_hash
-        _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || true
-        if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
+        local _gtr_trust_key
+        _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || true
+        if [ -n "$_gtr_trust_key" ] && [ -f "$_gtr_trust_dir/$_gtr_trust_key" ]; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -528,6 +545,15 @@ function __FUNC___hooks_hash
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 end
 
+function __FUNC___hooks_trust_key
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_hook_hash (__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_hook_hash"; or return 1
+  set -l _gtr_repo_root (cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P)
+  test -n "$_gtr_repo_root"; or return 1
+  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
+end
+
 function __FUNC___run_post_cd_hooks
   set -l dir "$argv[1]"
   set -l _gtr_trust_dir "$HOME/.config/gtr/trusted"
@@ -547,8 +573,8 @@ function __FUNC___run_post_cd_hooks
       set -l _gtr_candidate_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
       if test (count $_gtr_candidate_hooks) -gt 0
         # Verify trust before including .gtrconfig hooks
-        set -l _gtr_hook_hash (__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)
-        if test -n "$_gtr_hook_hash"; and test -f "$_gtr_trust_dir/$_gtr_hook_hash"
+        set -l _gtr_trust_key (__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)
+        if test -n "$_gtr_trust_key"; and test -f "$_gtr_trust_dir/$_gtr_trust_key"
           set _gtr_file_hooks $_gtr_candidate_hooks
         else
           echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2
@@ -705,6 +731,7 @@ complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a adapter -d 'List avai
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a config -d 'Manage configuration'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a completion -d 'Generate shell completions'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a init -d 'Generate shell integration'
+complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a trust -d 'Trust .gtrconfig hooks'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a version -d 'Show version'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a help -d 'Show help'
 

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -182,14 +182,15 @@ end
 
 function __FUNC___hooks_current_content_hash
   set -l _gtr_config_file "$argv[1]"
-  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null)
-  test $status -eq 0; or return 1
-  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
+  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+  test $pipestatus[1] -eq 0; or return 1
+  test -n "$_gtr_hook_defs"; or return 1
+  printf '%s\n' "$_gtr_hook_defs"
 end
 
 function __FUNC___hooks_repo_root
   set -l _gtr_config_file "$argv[1]"
-  cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P
+  command sh -c 'cd "$1" 2>/dev/null && pwd -P' sh (dirname "$_gtr_config_file")
 end
 
 function __FUNC___hooks_canonical_config_path

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -65,10 +65,11 @@ cmd_init() {
       ;;
   esac
 
-  # Generate output (cached to ~/.cache/gtr/, auto-invalidates on version change)
+  # Generate output (cached to ~/.cache/gtr/, auto-invalidates on shell integration changes)
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gtr"
   local cache_file="$cache_dir/init-${func_name}.${shell}"
-  local cache_stamp="# gtr-cache: version=${GTR_VERSION:-unknown} func=$func_name shell=$shell"
+  local cache_schema="${GTR_INIT_CACHE_VERSION:-2}"
+  local cache_stamp="# gtr-cache: version=${GTR_VERSION:-unknown} init=${cache_schema} func=$func_name shell=$shell"
 
   # Return cached output if version matches
   if [ -f "$cache_file" ]; then
@@ -94,6 +95,26 @@ _init_bash() {
 # git-gtr shell integration (cached to ~/.cache/gtr/)
 # Setup: see git gtr help init
 
+__FUNC___gtrconfig_path() {
+  local _gtr_git_common_dir _gtr_repo_root
+  _gtr_git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+
+  if [ "$_gtr_git_common_dir" = ".git" ]; then
+    _gtr_repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  else
+    _gtr_repo_root="${_gtr_git_common_dir%/.git}"
+  fi
+
+  printf '%s/.gtrconfig\n' "$_gtr_repo_root"
+}
+
+__FUNC___hooks_hash() {
+  local _gtr_config_file="$1"
+  local _gtr_hook_defs
+  _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)" || return 1
+  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
+}
+
 __FUNC___run_post_cd_hooks() {
   local dir="$1"
   local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
@@ -105,14 +126,14 @@ __FUNC___run_post_cd_hooks() {
     # Read from git config (local > global > system)
     _gtr_hooks="$(git config --get-all gtr.hook.postCd 2>/dev/null)" || true
     # Read from .gtrconfig if it exists — only if trusted
-    _gtr_config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.gtrconfig"
+    _gtr_config_file="$(__FUNC___gtrconfig_path 2>/dev/null)" || true
     if [ -f "$_gtr_config_file" ]; then
       local _gtr_file_hooks
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
         local _gtr_hook_hash
-        _gtr_hook_hash="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)" || true
+        _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || true
         if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
@@ -253,7 +274,7 @@ ___FUNC___completion() {
 
   if [ "$COMP_CWORD" -eq 1 ]; then
     # First argument: cd + all git-gtr subcommands
-    COMPREPLY=($(compgen -W "cd new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init help version" -- "$cur"))
+    COMPREPLY=($(compgen -W "cd new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init trust help version" -- "$cur"))
   elif [ "${COMP_WORDS[1]}" = "cd" ] && [ "$COMP_CWORD" -eq 2 ]; then
     # Worktree names for cd
     local worktrees
@@ -278,6 +299,28 @@ _init_zsh() {
 # git-gtr shell integration (cached to ~/.cache/gtr/)
 # Setup: see git gtr help init
 
+__FUNC___gtrconfig_path() {
+  emulate -L zsh
+  local _gtr_git_common_dir _gtr_repo_root
+  _gtr_git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+
+  if [ "$_gtr_git_common_dir" = ".git" ]; then
+    _gtr_repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  else
+    _gtr_repo_root="${_gtr_git_common_dir%/.git}"
+  fi
+
+  printf '%s/.gtrconfig\n' "$_gtr_repo_root"
+}
+
+__FUNC___hooks_hash() {
+  emulate -L zsh
+  local _gtr_config_file="$1"
+  local _gtr_hook_defs
+  _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)" || return 1
+  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
+}
+
 __FUNC___run_post_cd_hooks() {
   emulate -L zsh
   local dir="$1"
@@ -290,14 +333,14 @@ __FUNC___run_post_cd_hooks() {
     # Read from git config (local > global > system)
     _gtr_hooks="$(git config --get-all gtr.hook.postCd 2>/dev/null)" || true
     # Read from .gtrconfig if it exists — only if trusted
-    _gtr_config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.gtrconfig"
+    _gtr_config_file="$(__FUNC___gtrconfig_path 2>/dev/null)" || true
     if [ -f "$_gtr_config_file" ]; then
       local _gtr_file_hooks
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
         local _gtr_hook_hash
-        _gtr_hook_hash="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)" || true
+        _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || true
         if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
@@ -465,6 +508,26 @@ _init_fish() {
 # Add to ~/.config/fish/config.fish:
 #   git gtr init fish | source
 
+function __FUNC___gtrconfig_path
+  set -l _gtr_git_common_dir (git rev-parse --git-common-dir 2>/dev/null)
+  test -n "$_gtr_git_common_dir"; or return 1
+
+  if test "$_gtr_git_common_dir" = ".git"
+    set -l _gtr_repo_root (git rev-parse --show-toplevel 2>/dev/null)
+    test -n "$_gtr_repo_root"; or return 1
+    printf '%s/.gtrconfig\n' "$_gtr_repo_root"
+  else
+    printf '%s/.gtrconfig\n' (string replace -r '/\\.git$' '' -- "$_gtr_git_common_dir")
+  end
+end
+
+function __FUNC___hooks_hash
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)
+  test $status -eq 0; or return 1
+  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
+end
+
 function __FUNC___run_post_cd_hooks
   set -l dir "$argv[1]"
   set -l _gtr_trust_dir "$HOME/.config/gtr/trusted"
@@ -478,13 +541,13 @@ function __FUNC___run_post_cd_hooks
     # Read from git config (local > global > system)
     set -l _gtr_git_hooks (git config --get-all gtr.hook.postCd 2>/dev/null)
     # Read from .gtrconfig if it exists — only if trusted
-    set -l _gtr_config_file (git rev-parse --show-toplevel 2>/dev/null)"/.gtrconfig"
+    set -l _gtr_config_file (__FUNC___gtrconfig_path 2>/dev/null)
     set -l _gtr_file_hooks
     if test -f "$_gtr_config_file"
       set -l _gtr_candidate_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
       if test (count $_gtr_candidate_hooks) -gt 0
         # Verify trust before including .gtrconfig hooks
-        set -l _gtr_hook_hash (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+        set -l _gtr_hook_hash (__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)
         if test -n "$_gtr_hook_hash"; and test -f "$_gtr_trust_dir/$_gtr_hook_hash"
           set _gtr_file_hooks $_gtr_candidate_hooks
         else

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -68,7 +68,7 @@ cmd_init() {
   # Generate output (cached to ~/.cache/gtr/, auto-invalidates on shell integration changes)
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gtr"
   local cache_file="$cache_dir/init-${func_name}.${shell}"
-  local cache_schema="${GTR_INIT_CACHE_VERSION:-4}"
+  local cache_schema="${GTR_INIT_CACHE_VERSION:-5}"
   local cache_stamp="# gtr-cache: version=${GTR_VERSION:-unknown} init=${cache_schema} func=$func_name shell=$shell"
 
   # Return cached output if version matches
@@ -90,12 +90,13 @@ cmd_init() {
   fi
 }
 
-_init_bash() {
-  cat <<'BASH'
-# git-gtr shell integration (cached to ~/.cache/gtr/)
-# Setup: see git gtr help init
+_init_emit_posix_trust_helpers() {
+  local shell_prelude="$1"
+  local template
 
+  template=$(cat <<'EOF'
 __FUNC___gtrconfig_path() {
+__SHELL_PRELUDE__
   local _gtr_git_common_dir _gtr_repo_root
   _gtr_git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
 
@@ -108,32 +109,131 @@ __FUNC___gtrconfig_path() {
   printf '%s/.gtrconfig\n' "$_gtr_repo_root"
 }
 
-__FUNC___hooks_hash() {
+__FUNC___hooks_current_content_hash() {
+__SHELL_PRELUDE__
   local _gtr_config_file="$1"
   local _gtr_hook_defs
   _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)" || return 1
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 }
 
-__FUNC___hooks_trust_key() {
+__FUNC___hooks_repo_root() {
+__SHELL_PRELUDE__
+  local _gtr_config_file="$1"
+  cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P
+}
+
+__FUNC___hooks_canonical_config_path() {
+__SHELL_PRELUDE__
+  local _gtr_config_file="$1"
+  local _gtr_repo_root
+  _gtr_repo_root="$(__FUNC___hooks_repo_root "$_gtr_config_file" 2>/dev/null)" || return 1
+  printf '%s/%s\n' "$_gtr_repo_root" "$(basename "$_gtr_config_file")"
+}
+
+__FUNC___hooks_current_trust_key() {
+__SHELL_PRELUDE__
   local _gtr_config_file="$1"
   local _gtr_hook_hash _gtr_repo_root
-  _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || return 1
-  _gtr_repo_root="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)" || return 1
+  _gtr_hook_hash="$(__FUNC___hooks_current_content_hash "$_gtr_config_file" 2>/dev/null)" || return 1
+  _gtr_repo_root="$(__FUNC___hooks_repo_root "$_gtr_config_file" 2>/dev/null)" || return 1
   printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
 }
 
-__FUNC___hooks_trusted() {
-  local _gtr_config_file="$1"
-  local _gtr_trust_dir="$2"
-  local _gtr_trust_key _gtr_marker _gtr_canonical_config
-  _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || return 1
-  [ -f "$_gtr_trust_dir/$_gtr_trust_key" ] || return 1
-  _gtr_marker="$(cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)" || return 1
-  _gtr_canonical_config="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)/$(basename "$_gtr_config_file")" || return 1
+__FUNC___hooks_marker_matches_config() {
+__SHELL_PRELUDE__
+  local _gtr_trust_path="$1"
+  local _gtr_config_file="$2"
+  local _gtr_marker _gtr_canonical_config
+  [ -f "$_gtr_trust_path" ] || return 1
+  _gtr_marker="$(cat "$_gtr_trust_path" 2>/dev/null)" || return 1
+  _gtr_canonical_config="$(__FUNC___hooks_canonical_config_path "$_gtr_config_file" 2>/dev/null)" || return 1
   [ "$_gtr_marker" = "$_gtr_canonical_config" ]
 }
 
+__FUNC___hooks_are_trusted() {
+__SHELL_PRELUDE__
+  local _gtr_config_file="$1"
+  local _gtr_trust_dir="$2"
+  local _gtr_trust_key
+  _gtr_trust_key="$(__FUNC___hooks_current_trust_key "$_gtr_config_file" 2>/dev/null)" || return 1
+  __FUNC___hooks_marker_matches_config "$_gtr_trust_dir/$_gtr_trust_key" "$_gtr_config_file"
+}
+EOF
+)
+
+  printf '%s\n' "${template//__SHELL_PRELUDE__/$shell_prelude}"
+}
+
+_init_emit_fish_trust_helpers() {
+  cat <<'FISH'
+function __FUNC___gtrconfig_path
+  set -l _gtr_git_common_dir (git rev-parse --git-common-dir 2>/dev/null)
+  test -n "$_gtr_git_common_dir"; or return 1
+
+  if test "$_gtr_git_common_dir" = ".git"
+    set -l _gtr_repo_root (git rev-parse --show-toplevel 2>/dev/null)
+    test -n "$_gtr_repo_root"; or return 1
+    printf '%s/.gtrconfig\n' "$_gtr_repo_root"
+  else
+    printf '%s/.gtrconfig\n' (string replace -r '/\\.git$' '' -- "$_gtr_git_common_dir")
+  end
+end
+
+function __FUNC___hooks_current_content_hash
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)
+  test $status -eq 0; or return 1
+  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
+end
+
+function __FUNC___hooks_repo_root
+  set -l _gtr_config_file "$argv[1]"
+  cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P
+end
+
+function __FUNC___hooks_canonical_config_path
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_repo_root (__FUNC___hooks_repo_root "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_repo_root"; or return 1
+  printf '%s/%s\n' "$_gtr_repo_root" (basename "$_gtr_config_file")
+end
+
+function __FUNC___hooks_current_trust_key
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_hook_hash (__FUNC___hooks_current_content_hash "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_hook_hash"; or return 1
+  set -l _gtr_repo_root (__FUNC___hooks_repo_root "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_repo_root"; or return 1
+  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
+end
+
+function __FUNC___hooks_marker_matches_config
+  set -l _gtr_trust_path "$argv[1]"
+  set -l _gtr_config_file "$argv[2]"
+  test -f "$_gtr_trust_path"; or return 1
+  set -l _gtr_marker (cat "$_gtr_trust_path" 2>/dev/null)
+  set -l _gtr_canonical_config (__FUNC___hooks_canonical_config_path "$_gtr_config_file" 2>/dev/null)
+  test "$_gtr_marker" = "$_gtr_canonical_config"
+end
+
+function __FUNC___hooks_are_trusted
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_trust_dir "$argv[2]"
+  set -l _gtr_trust_key (__FUNC___hooks_current_trust_key "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_trust_key"; or return 1
+  __FUNC___hooks_marker_matches_config "$_gtr_trust_dir/$_gtr_trust_key" "$_gtr_config_file"
+end
+FISH
+}
+
+_init_bash() {
+  cat <<'BASH'
+# git-gtr shell integration (cached to ~/.cache/gtr/)
+# Setup: see git gtr help init
+BASH
+  _init_emit_posix_trust_helpers ""
+  cat <<'BASH'
 __FUNC___run_post_cd_hooks() {
   local dir="$1"
   local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
@@ -151,7 +251,7 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
+        if __FUNC___hooks_are_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -315,50 +415,9 @@ _init_zsh() {
   cat <<'ZSH'
 # git-gtr shell integration (cached to ~/.cache/gtr/)
 # Setup: see git gtr help init
-
-__FUNC___gtrconfig_path() {
-  emulate -L zsh
-  local _gtr_git_common_dir _gtr_repo_root
-  _gtr_git_common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
-
-  if [ "$_gtr_git_common_dir" = ".git" ]; then
-    _gtr_repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
-  else
-    _gtr_repo_root="${_gtr_git_common_dir%/.git}"
-  fi
-
-  printf '%s/.gtrconfig\n' "$_gtr_repo_root"
-}
-
-__FUNC___hooks_hash() {
-  emulate -L zsh
-  local _gtr_config_file="$1"
-  local _gtr_hook_defs
-  _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)" || return 1
-  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
-}
-
-__FUNC___hooks_trust_key() {
-  emulate -L zsh
-  local _gtr_config_file="$1"
-  local _gtr_hook_hash _gtr_repo_root
-  _gtr_hook_hash="$(__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)" || return 1
-  _gtr_repo_root="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)" || return 1
-  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
-}
-
-__FUNC___hooks_trusted() {
-  emulate -L zsh
-  local _gtr_config_file="$1"
-  local _gtr_trust_dir="$2"
-  local _gtr_trust_key _gtr_marker _gtr_canonical_config
-  _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || return 1
-  [ -f "$_gtr_trust_dir/$_gtr_trust_key" ] || return 1
-  _gtr_marker="$(cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)" || return 1
-  _gtr_canonical_config="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)/$(basename "$_gtr_config_file")" || return 1
-  [ "$_gtr_marker" = "$_gtr_canonical_config" ]
-}
-
+ZSH
+  _init_emit_posix_trust_helpers "  emulate -L zsh"
+  cat <<'ZSH'
 __FUNC___run_post_cd_hooks() {
   emulate -L zsh
   local dir="$1"
@@ -377,7 +436,7 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
+        if __FUNC___hooks_are_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -543,47 +602,9 @@ _init_fish() {
 # git-gtr shell integration
 # Add to ~/.config/fish/config.fish:
 #   git gtr init fish | source
-
-function __FUNC___gtrconfig_path
-  set -l _gtr_git_common_dir (git rev-parse --git-common-dir 2>/dev/null)
-  test -n "$_gtr_git_common_dir"; or return 1
-
-  if test "$_gtr_git_common_dir" = ".git"
-    set -l _gtr_repo_root (git rev-parse --show-toplevel 2>/dev/null)
-    test -n "$_gtr_repo_root"; or return 1
-    printf '%s/.gtrconfig\n' "$_gtr_repo_root"
-  else
-    printf '%s/.gtrconfig\n' (string replace -r '/\\.git$' '' -- "$_gtr_git_common_dir")
-  end
-end
-
-function __FUNC___hooks_hash
-  set -l _gtr_config_file "$argv[1]"
-  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)
-  test $status -eq 0; or return 1
-  printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
-end
-
-function __FUNC___hooks_trust_key
-  set -l _gtr_config_file "$argv[1]"
-  set -l _gtr_hook_hash (__FUNC___hooks_hash "$_gtr_config_file" 2>/dev/null)
-  test -n "$_gtr_hook_hash"; or return 1
-  set -l _gtr_repo_root (cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P)
-  test -n "$_gtr_repo_root"; or return 1
-  printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
-end
-
-function __FUNC___hooks_trusted
-  set -l _gtr_config_file "$argv[1]"
-  set -l _gtr_trust_dir "$argv[2]"
-  set -l _gtr_trust_key (__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)
-  test -n "$_gtr_trust_key"; or return 1
-  test -f "$_gtr_trust_dir/$_gtr_trust_key"; or return 1
-  set -l _gtr_marker (cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)
-  set -l _gtr_canonical_config (cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P)"/"(basename "$_gtr_config_file")
-  test "$_gtr_marker" = "$_gtr_canonical_config"
-end
-
+FISH
+  _init_emit_fish_trust_helpers
+  cat <<'FISH'
 function __FUNC___run_post_cd_hooks
   set -l dir "$argv[1]"
   set -l _gtr_trust_dir "$HOME/.config/gtr/trusted"
@@ -603,7 +624,7 @@ function __FUNC___run_post_cd_hooks
       set -l _gtr_candidate_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
       if test (count $_gtr_candidate_hooks) -gt 0
         # Verify trust before including .gtrconfig hooks
-        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"
+        if __FUNC___hooks_are_trusted "$_gtr_config_file" "$_gtr_trust_dir"
           set _gtr_file_hooks $_gtr_candidate_hooks
         else
           echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -113,7 +113,7 @@ __FUNC___hooks_current_content_hash() {
 __SHELL_PRELUDE__
   local _gtr_config_file="$1"
   local _gtr_hook_defs
-  _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)" || return 1
+  _gtr_hook_defs="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null)" || return 1
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 }
 
@@ -182,7 +182,7 @@ end
 
 function __FUNC___hooks_current_content_hash
   set -l _gtr_config_file "$argv[1]"
-  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null)
+  set -l _gtr_hook_defs (git config -f "$_gtr_config_file" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null)
   test $status -eq 0; or return 1
   printf '%s\n' "$_gtr_hook_defs" | shasum -a 256 | cut -d' ' -f1
 end
@@ -783,7 +783,7 @@ complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a adapter -d 'List avai
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a config -d 'Manage configuration'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a completion -d 'Generate shell completions'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a init -d 'Generate shell integration'
-complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a trust -d 'Trust .gtrconfig hooks'
+complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a trust -d 'Trust .gtrconfig commands'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a version -d 'Show version'
 complete -f -c __FUNC__ -n '___FUNC___needs_subcommand' -a help -d 'Show help'
 

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -176,7 +176,7 @@ function __FUNC___gtrconfig_path
     test -n "$_gtr_repo_root"; or return 1
     printf '%s/.gtrconfig\n' "$_gtr_repo_root"
   else
-    printf '%s/.gtrconfig\n' (string replace -r '/\\.git$' '' -- "$_gtr_git_common_dir")
+    printf '%s/.gtrconfig\n' (string replace -r '/\.git$' '' -- "$_gtr_git_common_dir")
   end
 end
 

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -68,7 +68,7 @@ cmd_init() {
   # Generate output (cached to ~/.cache/gtr/, auto-invalidates on shell integration changes)
   local cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/gtr"
   local cache_file="$cache_dir/init-${func_name}.${shell}"
-  local cache_schema="${GTR_INIT_CACHE_VERSION:-3}"
+  local cache_schema="${GTR_INIT_CACHE_VERSION:-4}"
   local cache_stamp="# gtr-cache: version=${GTR_VERSION:-unknown} init=${cache_schema} func=$func_name shell=$shell"
 
   # Return cached output if version matches
@@ -123,6 +123,17 @@ __FUNC___hooks_trust_key() {
   printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
 }
 
+__FUNC___hooks_trusted() {
+  local _gtr_config_file="$1"
+  local _gtr_trust_dir="$2"
+  local _gtr_trust_key _gtr_marker _gtr_canonical_config
+  _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || return 1
+  [ -f "$_gtr_trust_dir/$_gtr_trust_key" ] || return 1
+  _gtr_marker="$(cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)" || return 1
+  _gtr_canonical_config="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)/$(basename "$_gtr_config_file")" || return 1
+  [ "$_gtr_marker" = "$_gtr_canonical_config" ]
+}
+
 __FUNC___run_post_cd_hooks() {
   local dir="$1"
   local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
@@ -140,9 +151,7 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        local _gtr_trust_key
-        _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || true
-        if [ -n "$_gtr_trust_key" ] && [ -f "$_gtr_trust_dir/$_gtr_trust_key" ]; then
+        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -338,6 +347,18 @@ __FUNC___hooks_trust_key() {
   printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
 }
 
+__FUNC___hooks_trusted() {
+  emulate -L zsh
+  local _gtr_config_file="$1"
+  local _gtr_trust_dir="$2"
+  local _gtr_trust_key _gtr_marker _gtr_canonical_config
+  _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || return 1
+  [ -f "$_gtr_trust_dir/$_gtr_trust_key" ] || return 1
+  _gtr_marker="$(cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)" || return 1
+  _gtr_canonical_config="$(cd "$(dirname "$_gtr_config_file")" 2>/dev/null && pwd -P)/$(basename "$_gtr_config_file")" || return 1
+  [ "$_gtr_marker" = "$_gtr_canonical_config" ]
+}
+
 __FUNC___run_post_cd_hooks() {
   emulate -L zsh
   local dir="$1"
@@ -356,9 +377,7 @@ __FUNC___run_post_cd_hooks() {
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
         # Verify trust before including .gtrconfig hooks
-        local _gtr_trust_key
-        _gtr_trust_key="$(__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)" || true
-        if [ -n "$_gtr_trust_key" ] && [ -f "$_gtr_trust_dir/$_gtr_trust_key" ]; then
+        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"; then
           if [ -n "$_gtr_hooks" ]; then
             _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
           else
@@ -554,6 +573,17 @@ function __FUNC___hooks_trust_key
   printf '%s\n%s\n' "$_gtr_repo_root" "$_gtr_hook_hash" | shasum -a 256 | cut -d' ' -f1
 end
 
+function __FUNC___hooks_trusted
+  set -l _gtr_config_file "$argv[1]"
+  set -l _gtr_trust_dir "$argv[2]"
+  set -l _gtr_trust_key (__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)
+  test -n "$_gtr_trust_key"; or return 1
+  test -f "$_gtr_trust_dir/$_gtr_trust_key"; or return 1
+  set -l _gtr_marker (cat "$_gtr_trust_dir/$_gtr_trust_key" 2>/dev/null)
+  set -l _gtr_canonical_config (cd (dirname "$_gtr_config_file") 2>/dev/null; and pwd -P)"/"(basename "$_gtr_config_file")
+  test "$_gtr_marker" = "$_gtr_canonical_config"
+end
+
 function __FUNC___run_post_cd_hooks
   set -l dir "$argv[1]"
   set -l _gtr_trust_dir "$HOME/.config/gtr/trusted"
@@ -573,8 +603,7 @@ function __FUNC___run_post_cd_hooks
       set -l _gtr_candidate_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
       if test (count $_gtr_candidate_hooks) -gt 0
         # Verify trust before including .gtrconfig hooks
-        set -l _gtr_trust_key (__FUNC___hooks_trust_key "$_gtr_config_file" 2>/dev/null)
-        if test -n "$_gtr_trust_key"; and test -f "$_gtr_trust_dir/$_gtr_trust_key"
+        if __FUNC___hooks_trusted "$_gtr_config_file" "$_gtr_trust_dir"
           set _gtr_file_hooks $_gtr_candidate_hooks
         else
           echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2

--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -96,6 +96,7 @@ _init_bash() {
 
 __FUNC___run_post_cd_hooks() {
   local dir="$1"
+  local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
 
   cd "$dir" && {
     local _gtr_hooks _gtr_hook _gtr_seen _gtr_config_file
@@ -103,16 +104,23 @@ __FUNC___run_post_cd_hooks() {
     _gtr_seen=""
     # Read from git config (local > global > system)
     _gtr_hooks="$(git config --get-all gtr.hook.postCd 2>/dev/null)" || true
-    # Read from .gtrconfig if it exists
+    # Read from .gtrconfig if it exists — only if trusted
     _gtr_config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.gtrconfig"
     if [ -f "$_gtr_config_file" ]; then
       local _gtr_file_hooks
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
-        if [ -n "$_gtr_hooks" ]; then
-          _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
+        # Verify trust before including .gtrconfig hooks
+        local _gtr_hook_hash
+        _gtr_hook_hash="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)" || true
+        if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
+          if [ -n "$_gtr_hooks" ]; then
+            _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
+          else
+            _gtr_hooks="$_gtr_file_hooks"
+          fi
         else
-          _gtr_hooks="$_gtr_file_hooks"
+          echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2
         fi
       fi
     fi
@@ -273,6 +281,7 @@ _init_zsh() {
 __FUNC___run_post_cd_hooks() {
   emulate -L zsh
   local dir="$1"
+  local _gtr_trust_dir="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
 
   cd "$dir" && {
     local _gtr_hooks _gtr_hook _gtr_seen _gtr_config_file
@@ -280,16 +289,23 @@ __FUNC___run_post_cd_hooks() {
     _gtr_seen=""
     # Read from git config (local > global > system)
     _gtr_hooks="$(git config --get-all gtr.hook.postCd 2>/dev/null)" || true
-    # Read from .gtrconfig if it exists
+    # Read from .gtrconfig if it exists — only if trusted
     _gtr_config_file="$(git rev-parse --show-toplevel 2>/dev/null)/.gtrconfig"
     if [ -f "$_gtr_config_file" ]; then
       local _gtr_file_hooks
       _gtr_file_hooks="$(git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)" || true
       if [ -n "$_gtr_file_hooks" ]; then
-        if [ -n "$_gtr_hooks" ]; then
-          _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
+        # Verify trust before including .gtrconfig hooks
+        local _gtr_hook_hash
+        _gtr_hook_hash="$(git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)" || true
+        if [ -n "$_gtr_hook_hash" ] && [ -f "$_gtr_trust_dir/$_gtr_hook_hash" ]; then
+          if [ -n "$_gtr_hooks" ]; then
+            _gtr_hooks="$_gtr_hooks"$'\n'"$_gtr_file_hooks"
+          else
+            _gtr_hooks="$_gtr_file_hooks"
+          fi
         else
-          _gtr_hooks="$_gtr_file_hooks"
+          echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2
         fi
       fi
     fi
@@ -451,17 +467,30 @@ _init_fish() {
 
 function __FUNC___run_post_cd_hooks
   set -l dir "$argv[1]"
+  set -l _gtr_trust_dir "$HOME/.config/gtr/trusted"
+  if set -q XDG_CONFIG_HOME
+    set _gtr_trust_dir "$XDG_CONFIG_HOME/gtr/trusted"
+  end
   cd $dir
   and begin
     set -l _gtr_hooks
     set -l _gtr_seen
     # Read from git config (local > global > system)
     set -l _gtr_git_hooks (git config --get-all gtr.hook.postCd 2>/dev/null)
-    # Read from .gtrconfig if it exists
+    # Read from .gtrconfig if it exists — only if trusted
     set -l _gtr_config_file (git rev-parse --show-toplevel 2>/dev/null)"/.gtrconfig"
     set -l _gtr_file_hooks
     if test -f "$_gtr_config_file"
-      set _gtr_file_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
+      set -l _gtr_candidate_hooks (git config -f "$_gtr_config_file" --get-all hooks.postCd 2>/dev/null)
+      if test (count $_gtr_candidate_hooks) -gt 0
+        # Verify trust before including .gtrconfig hooks
+        set -l _gtr_hook_hash (git config -f "$_gtr_config_file" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+        if test -n "$_gtr_hook_hash"; and test -f "$_gtr_trust_dir/$_gtr_hook_hash"
+          set _gtr_file_hooks $_gtr_candidate_hooks
+        else
+          echo "__FUNC__: Untrusted .gtrconfig hooks skipped — run 'git gtr trust' to approve" >&2
+        end
+      end
     end
     # Merge and deduplicate
     set _gtr_hooks $_gtr_git_hooks $_gtr_file_hooks

--- a/lib/commands/trust.sh
+++ b/lib/commands/trust.sh
@@ -26,6 +26,12 @@ cmd_trust() {
     return 0
   fi
 
+  local trust_path
+  trust_path=$(_hooks_trust_path_for_content "$config_file" "$hook_content") || {
+    log_error "Failed to compute trust marker for $config_file"
+    return 1
+  }
+
   log_warn "The following hooks are defined in $config_file:"
   echo "" >&2
   printf '%s\n' "$hook_content" >&2
@@ -33,7 +39,13 @@ cmd_trust() {
   log_warn "These commands will execute on your machine during gtr operations."
 
   if prompt_yes_no "Trust these hooks?"; then
-    if _hooks_mark_trusted "$config_file"; then
+    if _hooks_write_trust_marker "$trust_path" "$config_file"; then
+      local current_trust_path
+      current_trust_path=$(_hooks_trust_path "$config_file") || true
+      if [ -n "$current_trust_path" ] && [ "$current_trust_path" != "$trust_path" ]; then
+        log_warn "Hooks changed during review; current hooks remain untrusted"
+        return 1
+      fi
       log_info "Hooks marked as trusted"
     else
       log_error "Failed to mark hooks as trusted"

--- a/lib/commands/trust.sh
+++ b/lib/commands/trust.sh
@@ -33,8 +33,12 @@ cmd_trust() {
   log_warn "These commands will execute on your machine during gtr operations."
 
   if prompt_yes_no "Trust these hooks?"; then
-    _hooks_mark_trusted "$config_file"
-    log_info "Hooks marked as trusted"
+    if _hooks_mark_trusted "$config_file"; then
+      log_info "Hooks marked as trusted"
+    else
+      log_error "Failed to mark hooks as trusted"
+      return 1
+    fi
   else
     log_info "Hooks remain untrusted and will not execute"
   fi

--- a/lib/commands/trust.sh
+++ b/lib/commands/trust.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Trust management for .gtrconfig hooks
+# Trust management for executable .gtrconfig commands
 
 cmd_trust() {
   local config_file
@@ -10,18 +10,18 @@ cmd_trust() {
     return 0
   fi
 
-  # Show all hook entries from .gtrconfig
+  # Show all trusted command entries from .gtrconfig
   local hook_content
-  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+  hook_content=$(_hooks_read_definitions "$config_file") || true
 
   if [ -z "$hook_content" ]; then
-    log_info "No hooks defined in $config_file"
+    log_info "No hooks or executable defaults defined in $config_file"
     return 0
   fi
 
   if _hooks_are_trusted "$config_file"; then
-    log_info "Hooks in $config_file are already trusted"
-    log_info "Current hooks:"
+    log_info "Executable commands in $config_file are already trusted"
+    log_info "Current trusted commands:"
     printf '%s\n' "$hook_content" >&2
     return 0
   fi
@@ -32,26 +32,26 @@ cmd_trust() {
     return 1
   }
 
-  log_warn "The following hooks are defined in $config_file:"
+  log_warn "The following executable commands are defined in $config_file:"
   echo "" >&2
   printf '%s\n' "$hook_content" >&2
   echo "" >&2
   log_warn "These commands will execute on your machine during gtr operations."
 
-  if prompt_yes_no "Trust these hooks?"; then
+  if prompt_yes_no "Trust these commands?"; then
     if _hooks_write_trust_marker "$trust_path" "$config_file"; then
       local current_trust_path
       current_trust_path=$(_hooks_current_trust_path "$config_file") || true
       if [ -n "$current_trust_path" ] && [ "$current_trust_path" != "$trust_path" ]; then
-        log_warn "Hooks changed during review; current hooks remain untrusted"
+        log_warn "Executable commands changed during review; current commands remain untrusted"
         return 1
       fi
-      log_info "Hooks marked as trusted"
+      log_info "Executable commands marked as trusted"
     else
-      log_error "Failed to mark hooks as trusted"
+      log_error "Failed to mark executable commands as trusted"
       return 1
     fi
   else
-    log_info "Hooks remain untrusted and will not execute"
+    log_info "Executable commands remain untrusted and will not run from .gtrconfig"
   fi
 }

--- a/lib/commands/trust.sh
+++ b/lib/commands/trust.sh
@@ -27,7 +27,7 @@ cmd_trust() {
   fi
 
   local trust_path
-  trust_path=$(_hooks_trust_path_for_content "$config_file" "$hook_content") || {
+  trust_path=$(_hooks_reviewed_trust_path "$config_file" "$hook_content") || {
     log_error "Failed to compute trust marker for $config_file"
     return 1
   }
@@ -41,7 +41,7 @@ cmd_trust() {
   if prompt_yes_no "Trust these hooks?"; then
     if _hooks_write_trust_marker "$trust_path" "$config_file"; then
       local current_trust_path
-      current_trust_path=$(_hooks_trust_path "$config_file") || true
+      current_trust_path=$(_hooks_current_trust_path "$config_file") || true
       if [ -n "$current_trust_path" ] && [ "$current_trust_path" != "$trust_path" ]; then
         log_warn "Hooks changed during review; current hooks remain untrusted"
         return 1

--- a/lib/commands/trust.sh
+++ b/lib/commands/trust.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Trust management for .gtrconfig hooks
+
+cmd_trust() {
+  local config_file
+  config_file=$(_gtrconfig_path)
+
+  if [ -z "$config_file" ] || [ ! -f "$config_file" ]; then
+    log_info "No .gtrconfig file found in this repository"
+    return 0
+  fi
+
+  # Show all hook entries from .gtrconfig
+  local hook_content
+  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+
+  if [ -z "$hook_content" ]; then
+    log_info "No hooks defined in $config_file"
+    return 0
+  fi
+
+  if _hooks_are_trusted "$config_file"; then
+    log_info "Hooks in $config_file are already trusted"
+    log_info "Current hooks:"
+    printf '%s\n' "$hook_content" >&2
+    return 0
+  fi
+
+  log_warn "The following hooks are defined in $config_file:"
+  echo "" >&2
+  printf '%s\n' "$hook_content" >&2
+  echo "" >&2
+  log_warn "These commands will execute on your machine during gtr operations."
+
+  if prompt_yes_no "Trust these hooks?"; then
+    _hooks_mark_trusted "$config_file"
+    log_info "Hooks marked as trusted"
+  else
+    log_info "Hooks remain untrusted and will not execute"
+  fi
+}

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -408,9 +408,9 @@ cfg_default() {
     value=$(git config --get "$key" 2>/dev/null || true)
   fi
 
-  # 4. Fall back to environment variable (POSIX-compliant indirect reference)
+  # 4. Fall back to environment variable
   if [ -z "$value" ] && [ -n "$env_name" ]; then
-    eval "value=\${${env_name}:-}"
+    value=$(printenv "$env_name" 2>/dev/null) || true
   fi
 
   # 5. Use fallback if still empty

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -431,3 +431,54 @@ cfg_default() {
   # 5. Use fallback if still empty
   printf "%s" "${value:-$fallback}"
 }
+
+# Get a default config value while trust-gating the .gtrconfig source.
+# Usage: cfg_default_trusted_file key env_name fallback_value file_key
+# Precedence: local config > trusted .gtrconfig > global/system config > env var > fallback
+cfg_default_trusted_file() {
+  local key="$1"
+  local env_name="$2"
+  local fallback="$3"
+  local file_key="${4:-}"
+  local value file_value config_file
+
+  # Auto-map file_key if not provided and key is a gtr.* key
+  if [ -z "$file_key" ] && [[ "$key" == gtr.* ]]; then
+    file_key=$(cfg_map_to_file_key "$key")
+  fi
+
+  # 1. Try local git config first (highest priority)
+  value=$(git config --local --get "$key" 2>/dev/null || true)
+
+  # 2. Try .gtrconfig file only if its trusted command definitions are approved
+  if [ -z "$value" ] && [ -n "$file_key" ]; then
+    config_file=$(_gtrconfig_path)
+    if [ -n "$config_file" ] && [ -f "$config_file" ]; then
+      file_value=$(git config -f "$config_file" --get "$file_key" 2>/dev/null || true)
+      if [ -n "$file_value" ]; then
+        if _hooks_are_trusted "$config_file"; then
+          value="$file_value"
+        else
+          log_warn "Untrusted .gtrconfig $file_key skipped — run: git gtr trust"
+        fi
+      fi
+    fi
+  fi
+
+  # 3. Try global/system git config
+  if [ -z "$value" ]; then
+    value=$(git config --global --get "$key" 2>/dev/null || true)
+  fi
+
+  if [ -z "$value" ]; then
+    value=$(git config --system --get "$key" 2>/dev/null || true)
+  fi
+
+  # 4. Fall back to environment variable
+  if [ -z "$value" ] && [ -n "$env_name" ]; then
+    value=$(printenv "$env_name" 2>/dev/null) || true
+  fi
+
+  # 5. Use fallback if still empty
+  printf "%s" "${value:-$fallback}"
+}

--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -282,10 +282,17 @@ _apply_directory_excludes() {
         local pattern_prefix="${exclude_pattern%%/*}"
         local pattern_suffix="${exclude_pattern#*/}"
 
-        # Reject bare glob-only suffixes that would match everything
+        # Reject empty suffixes and protect Git metadata from removal
         case "$pattern_suffix" in
-          ""|"*"|"**"|".*")
+          "")
             log_warn "Skipping overly broad exclude suffix: $exclude_pattern"
+            continue
+            ;;
+        esac
+
+        case "$exclude_pattern" in
+          .git|*/.git|.git/*|*/.git/*)
+            log_warn "Skipping exclude pattern targeting .git metadata: $exclude_pattern"
             continue
             ;;
         esac

--- a/lib/copy.sh
+++ b/lib/copy.sh
@@ -282,6 +282,14 @@ _apply_directory_excludes() {
         local pattern_prefix="${exclude_pattern%%/*}"
         local pattern_suffix="${exclude_pattern#*/}"
 
+        # Reject bare glob-only suffixes that would match everything
+        case "$pattern_suffix" in
+          ""|"*"|"**"|".*")
+            log_warn "Skipping overly broad exclude suffix: $exclude_pattern"
+            continue
+            ;;
+        esac
+
         # Intentional glob pattern matching for directory prefix
         # shellcheck disable=SC2254
         case "$dir_path" in
@@ -295,8 +303,13 @@ _apply_directory_excludes() {
             shopt -s dotglob 2>/dev/null || true
 
             local removed_any=0
+            # shellcheck disable=SC2086
             for matched_path in $pattern_suffix; do
               if [ -e "$matched_path" ]; then
+                # Never remove .git directory via exclude patterns
+                case "$matched_path" in
+                  .git|.git/*) continue ;;
+                esac
                 if rm -rf "$matched_path" 2>/dev/null; then
                   removed_any=1
                 fi

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -20,7 +20,16 @@ _hooks_file_hash() {
   if [ -z "$hook_content" ]; then
     return 1
   fi
-  printf '%s' "$hook_content" | shasum -a 256 | cut -d' ' -f1
+  printf '%s\n' "$hook_content" | shasum -a 256 | cut -d' ' -f1
+}
+
+# Resolve the trust marker path for a .gtrconfig file
+# Usage: _hooks_trust_path <config_file>
+_hooks_trust_path() {
+  local config_file="$1"
+  local hash
+  hash=$(_hooks_file_hash "$config_file") || return 1
+  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$hash"
 }
 
 # Check if .gtrconfig hooks are trusted for the current repository
@@ -30,21 +39,21 @@ _hooks_are_trusted() {
   local config_file="$1"
   [ ! -f "$config_file" ] && return 0
 
-  local hash
-  hash=$(_hooks_file_hash "$config_file") || return 0  # no hooks = trusted
+  local trust_path
+  trust_path=$(_hooks_trust_path "$config_file") || return 0  # no hooks = trusted
 
-  [ -f "$_GTR_TRUST_DIR/$hash" ]
+  [ -f "$trust_path" ]
 }
 
 # Mark .gtrconfig hooks as trusted
 # Usage: _hooks_mark_trusted <config_file>
 _hooks_mark_trusted() {
   local config_file="$1"
-  local hash
-  hash=$(_hooks_file_hash "$config_file") || return 0
+  local trust_path
+  trust_path=$(_hooks_trust_path "$config_file") || return 0
 
   mkdir -p "$_GTR_TRUST_DIR"
-  printf '%s\n' "$config_file" > "$_GTR_TRUST_DIR/$hash"
+  printf '%s\n' "$config_file" > "$trust_path"
 }
 
 # Get hooks, filtering out untrusted .gtrconfig hooks with a warning

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -8,10 +8,21 @@
 #
 # Trust state is stored in ~/.config/gtr/trusted/<key>
 # where <key> is a SHA-256 of the canonical repo root plus the hook content hash.
+# Trust is scoped to repo identity + hook definitions, not repo snapshot state.
 
 _GTR_TRUST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
 
-# Compute a content hash for hook definitions
+# Read all hook definitions from a .gtrconfig file.
+# Usage: _hooks_read_definitions <config_file>
+_hooks_read_definitions() {
+  local config_file="$1"
+  local hook_content
+  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+  [ -n "$hook_content" ] || return 1
+  printf '%s\n' "$hook_content"
+}
+
+# Compute a content hash for hook definitions.
 # Usage: _hooks_content_hash <hook_content>
 _hooks_content_hash() {
   local hook_content="$1"
@@ -19,13 +30,18 @@ _hooks_content_hash() {
   printf '%s\n' "$hook_content" | shasum -a 256 | cut -d' ' -f1
 }
 
-# Compute a content hash of all hook entries in a .gtrconfig file
-# Usage: _hooks_file_hash <config_file>
-_hooks_file_hash() {
+# Compute a content hash of all current hook entries in a .gtrconfig file.
+# Usage: _hooks_current_content_hash <config_file>
+_hooks_current_content_hash() {
   local config_file="$1"
   local hook_content
-  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+  hook_content=$(_hooks_read_definitions "$config_file") || return 1
   _hooks_content_hash "$hook_content"
+}
+
+# Backward-compatible alias used by tests and older call sites.
+_hooks_file_hash() {
+  _hooks_current_content_hash "$1"
 }
 
 # Resolve the canonical repository root for a .gtrconfig file
@@ -47,19 +63,9 @@ _hooks_canonical_config_path() {
   printf '%s/%s\n' "$repo_root" "$(basename "$config_file")"
 }
 
-# Compute the repo-scoped trust key for a .gtrconfig file
-# Usage: _hooks_trust_key <config_file>
-_hooks_trust_key() {
-  local config_file="$1"
-  local hash repo_root
-  hash=$(_hooks_file_hash "$config_file") || return 1
-  repo_root=$(_hooks_repo_root "$config_file") || return 1
-  printf '%s\n%s\n' "$repo_root" "$hash" | shasum -a 256 | cut -d' ' -f1
-}
-
 # Compute the repo-scoped trust key for reviewed hook content
-# Usage: _hooks_trust_key_for_content <config_file> <hook_content>
-_hooks_trust_key_for_content() {
+# Usage: _hooks_reviewed_trust_key <config_file> <hook_content>
+_hooks_reviewed_trust_key() {
   local config_file="$1"
   local hook_content="$2"
   local hash repo_root
@@ -68,23 +74,59 @@ _hooks_trust_key_for_content() {
   printf '%s\n%s\n' "$repo_root" "$hash" | shasum -a 256 | cut -d' ' -f1
 }
 
-# Resolve the trust marker path for a .gtrconfig file
-# Usage: _hooks_trust_path <config_file>
-_hooks_trust_path() {
+# Compute the repo-scoped trust key for the current hook content
+# Usage: _hooks_current_trust_key <config_file>
+_hooks_current_trust_key() {
   local config_file="$1"
-  local trust_key
-  trust_key=$(_hooks_trust_key "$config_file") || return 1
-  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$trust_key"
+  local hook_content
+  hook_content=$(_hooks_read_definitions "$config_file") || return 1
+  _hooks_reviewed_trust_key "$config_file" "$hook_content"
+}
+
+# Backward-compatible alias used by existing call sites.
+_hooks_trust_key() {
+  _hooks_current_trust_key "$1"
 }
 
 # Resolve the trust marker path for reviewed hook content
-# Usage: _hooks_trust_path_for_content <config_file> <hook_content>
-_hooks_trust_path_for_content() {
+# Usage: _hooks_reviewed_trust_path <config_file> <hook_content>
+_hooks_reviewed_trust_path() {
   local config_file="$1"
   local hook_content="$2"
   local trust_key
-  trust_key=$(_hooks_trust_key_for_content "$config_file" "$hook_content") || return 1
+  trust_key=$(_hooks_reviewed_trust_key "$config_file" "$hook_content") || return 1
   printf '%s/%s\n' "$_GTR_TRUST_DIR" "$trust_key"
+}
+
+# Resolve the trust marker path for a .gtrconfig file
+# Usage: _hooks_current_trust_path <config_file>
+_hooks_current_trust_path() {
+  local config_file="$1"
+  local trust_key
+  trust_key=$(_hooks_current_trust_key "$config_file") || return 1
+  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$trust_key"
+}
+
+# Backward-compatible aliases used by existing call sites.
+_hooks_trust_path() {
+  _hooks_current_trust_path "$1"
+}
+
+_hooks_trust_path_for_content() {
+  _hooks_reviewed_trust_path "$1" "$2"
+}
+
+# Check whether a trust marker matches the canonical config path.
+# Usage: _hooks_marker_matches_config <trust_path> <config_file>
+_hooks_marker_matches_config() {
+  local trust_path="$1"
+  local config_file="$2"
+  local marker_content canonical_config_file
+
+  [ -f "$trust_path" ] || return 1
+  marker_content="$(cat "$trust_path" 2>/dev/null)" || return 1
+  canonical_config_file=$(_hooks_canonical_config_path "$config_file") || return 1
+  [ "$marker_content" = "$canonical_config_file" ]
 }
 
 # Check if .gtrconfig hooks are trusted for the current repository
@@ -95,14 +137,8 @@ _hooks_are_trusted() {
   [ ! -f "$config_file" ] && return 0
 
   local trust_path
-  trust_path=$(_hooks_trust_path "$config_file") || return 0  # no hooks = trusted
-
-  [ -f "$trust_path" ] || return 1
-
-  local marker_content canonical_config_file
-  marker_content="$(cat "$trust_path" 2>/dev/null)" || return 1
-  canonical_config_file=$(_hooks_canonical_config_path "$config_file") || return 1
-  [ "$marker_content" = "$canonical_config_file" ]
+  trust_path=$(_hooks_current_trust_path "$config_file") || return 0  # no hooks = trusted
+  _hooks_marker_matches_config "$trust_path" "$config_file"
 }
 
 # Write a trust marker that matches the reviewed hooks
@@ -133,7 +169,7 @@ _hooks_write_trust_marker() {
 _hooks_mark_trusted() {
   local config_file="$1"
   local trust_path
-  trust_path=$(_hooks_trust_path "$config_file") || return 0
+  trust_path=$(_hooks_current_trust_path "$config_file") || return 0
 
   _hooks_write_trust_marker "$trust_path" "$config_file"
 }

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -136,8 +136,9 @@ _hooks_are_trusted() {
   local config_file="$1"
   [ ! -f "$config_file" ] && return 0
 
-  local trust_path
-  trust_path=$(_hooks_current_trust_path "$config_file") || return 0  # no hooks = trusted
+  local hook_content trust_path
+  hook_content=$(_hooks_read_definitions "$config_file") || return 0
+  trust_path=$(_hooks_reviewed_trust_path "$config_file" "$hook_content") || return 1
   _hooks_marker_matches_config "$trust_path" "$config_file"
 }
 
@@ -168,8 +169,9 @@ _hooks_write_trust_marker() {
 # Usage: _hooks_mark_trusted <config_file>
 _hooks_mark_trusted() {
   local config_file="$1"
-  local trust_path
-  trust_path=$(_hooks_current_trust_path "$config_file") || return 0
+  local hook_content trust_path
+  hook_content=$(_hooks_read_definitions "$config_file") || return 0
+  trust_path=$(_hooks_reviewed_trust_path "$config_file" "$hook_content") || return 1
 
   _hooks_write_trust_marker "$trust_path" "$config_file"
 }

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -114,8 +114,8 @@ _hooks_write_trust_marker() {
   local canonical_config_file=""
 
   mkdir -p "$_GTR_TRUST_DIR" || return 1
-  temp_path="$(mktemp "$_GTR_TRUST_DIR/.trust.XXXXXX")" || return 1
   canonical_config_file=$(_hooks_canonical_config_path "$config_file") || return 1
+  temp_path="$(mktemp "$_GTR_TRUST_DIR/.trust.XXXXXX")" || return 1
 
   if ! printf '%s\n' "$canonical_config_file" > "$temp_path"; then
     rm -f "$temp_path"

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -6,10 +6,18 @@
 # user approval before execution. This prevents malicious contributors from
 # injecting arbitrary commands via shared config files.
 #
-# Trust state is stored per-repo in ~/.config/gtr/trusted/<hash>
-# where <hash> is the SHA-256 of the .gtrconfig hooks content.
+# Trust state is stored in ~/.config/gtr/trusted/<key>
+# where <key> is a SHA-256 of the canonical repo root plus the hook content hash.
 
 _GTR_TRUST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
+
+# Compute a content hash for hook definitions
+# Usage: _hooks_content_hash <hook_content>
+_hooks_content_hash() {
+  local hook_content="$1"
+  [ -n "$hook_content" ] || return 1
+  printf '%s\n' "$hook_content" | shasum -a 256 | cut -d' ' -f1
+}
 
 # Compute a content hash of all hook entries in a .gtrconfig file
 # Usage: _hooks_file_hash <config_file>
@@ -17,19 +25,57 @@ _hooks_file_hash() {
   local config_file="$1"
   local hook_content
   hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
-  if [ -z "$hook_content" ]; then
-    return 1
-  fi
-  printf '%s\n' "$hook_content" | shasum -a 256 | cut -d' ' -f1
+  _hooks_content_hash "$hook_content"
+}
+
+# Resolve the canonical repository root for a .gtrconfig file
+# Usage: _hooks_repo_root <config_file>
+_hooks_repo_root() {
+  local config_file="$1"
+  (
+    cd "$(dirname "$config_file")" 2>/dev/null &&
+    pwd -P
+  )
+}
+
+# Compute the repo-scoped trust key for a .gtrconfig file
+# Usage: _hooks_trust_key <config_file>
+_hooks_trust_key() {
+  local config_file="$1"
+  local hash repo_root
+  hash=$(_hooks_file_hash "$config_file") || return 1
+  repo_root=$(_hooks_repo_root "$config_file") || return 1
+  printf '%s\n%s\n' "$repo_root" "$hash" | shasum -a 256 | cut -d' ' -f1
+}
+
+# Compute the repo-scoped trust key for reviewed hook content
+# Usage: _hooks_trust_key_for_content <config_file> <hook_content>
+_hooks_trust_key_for_content() {
+  local config_file="$1"
+  local hook_content="$2"
+  local hash repo_root
+  hash=$(_hooks_content_hash "$hook_content") || return 1
+  repo_root=$(_hooks_repo_root "$config_file") || return 1
+  printf '%s\n%s\n' "$repo_root" "$hash" | shasum -a 256 | cut -d' ' -f1
 }
 
 # Resolve the trust marker path for a .gtrconfig file
 # Usage: _hooks_trust_path <config_file>
 _hooks_trust_path() {
   local config_file="$1"
-  local hash
-  hash=$(_hooks_file_hash "$config_file") || return 1
-  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$hash"
+  local trust_key
+  trust_key=$(_hooks_trust_key "$config_file") || return 1
+  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$trust_key"
+}
+
+# Resolve the trust marker path for reviewed hook content
+# Usage: _hooks_trust_path_for_content <config_file> <hook_content>
+_hooks_trust_path_for_content() {
+  local config_file="$1"
+  local hook_content="$2"
+  local trust_key
+  trust_key=$(_hooks_trust_key_for_content "$config_file" "$hook_content") || return 1
+  printf '%s/%s\n' "$_GTR_TRUST_DIR" "$trust_key"
 }
 
 # Check if .gtrconfig hooks are trusted for the current repository
@@ -45,6 +91,16 @@ _hooks_are_trusted() {
   [ -f "$trust_path" ]
 }
 
+# Write a trust marker that matches the reviewed hooks
+# Usage: _hooks_write_trust_marker <trust_path> [config_file]
+_hooks_write_trust_marker() {
+  local trust_path="$1"
+  local config_file="${2:-}"
+
+  mkdir -p "$_GTR_TRUST_DIR" || return 1
+  printf '%s\n' "$config_file" > "$trust_path"
+}
+
 # Mark .gtrconfig hooks as trusted
 # Usage: _hooks_mark_trusted <config_file>
 _hooks_mark_trusted() {
@@ -52,8 +108,7 @@ _hooks_mark_trusted() {
   local trust_path
   trust_path=$(_hooks_trust_path "$config_file") || return 0
 
-  mkdir -p "$_GTR_TRUST_DIR"
-  printf '%s\n' "$config_file" > "$trust_path"
+  _hooks_write_trust_marker "$trust_path" "$config_file"
 }
 
 # Get hooks, filtering out untrusted .gtrconfig hooks with a warning

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -38,6 +38,15 @@ _hooks_repo_root() {
   )
 }
 
+# Resolve the canonical path for a .gtrconfig file
+# Usage: _hooks_canonical_config_path <config_file>
+_hooks_canonical_config_path() {
+  local config_file="$1"
+  local repo_root
+  repo_root=$(_hooks_repo_root "$config_file") || return 1
+  printf '%s/%s\n' "$repo_root" "$(basename "$config_file")"
+}
+
 # Compute the repo-scoped trust key for a .gtrconfig file
 # Usage: _hooks_trust_key <config_file>
 _hooks_trust_key() {
@@ -88,7 +97,12 @@ _hooks_are_trusted() {
   local trust_path
   trust_path=$(_hooks_trust_path "$config_file") || return 0  # no hooks = trusted
 
-  [ -f "$trust_path" ]
+  [ -f "$trust_path" ] || return 1
+
+  local marker_content canonical_config_file
+  marker_content="$(cat "$trust_path" 2>/dev/null)" || return 1
+  canonical_config_file=$(_hooks_canonical_config_path "$config_file") || return 1
+  [ "$marker_content" = "$canonical_config_file" ]
 }
 
 # Write a trust marker that matches the reviewed hooks
@@ -96,9 +110,22 @@ _hooks_are_trusted() {
 _hooks_write_trust_marker() {
   local trust_path="$1"
   local config_file="${2:-}"
+  local temp_path=""
+  local canonical_config_file=""
 
   mkdir -p "$_GTR_TRUST_DIR" || return 1
-  printf '%s\n' "$config_file" > "$trust_path"
+  temp_path="$(mktemp "$_GTR_TRUST_DIR/.trust.XXXXXX")" || return 1
+  canonical_config_file=$(_hooks_canonical_config_path "$config_file") || return 1
+
+  if ! printf '%s\n' "$canonical_config_file" > "$temp_path"; then
+    rm -f "$temp_path"
+    return 1
+  fi
+
+  if ! mv -f "$temp_path" "$trust_path"; then
+    rm -f "$temp_path"
+    return 1
+  fi
 }
 
 # Mark .gtrconfig hooks as trusted

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -2,27 +2,29 @@
 # Hook execution system
 
 # ── Hook trust model ────────────────────────────────────────────────────
-# Hooks from .gtrconfig files (committed to repositories) require explicit
-# user approval before execution. This prevents malicious contributors from
-# injecting arbitrary commands via shared config files.
+# Hooks and executable defaults from .gtrconfig files (committed to
+# repositories) require explicit user approval before use. This prevents
+# malicious contributors from injecting arbitrary commands via shared config
+# files.
 #
 # Trust state is stored in ~/.config/gtr/trusted/<key>
-# where <key> is a SHA-256 of the canonical repo root plus the hook content hash.
-# Trust is scoped to repo identity + hook definitions, not repo snapshot state.
+# where <key> is a SHA-256 of the canonical repo root plus trusted content hash.
+# Trust is scoped to repo identity + trusted .gtrconfig definitions, not repo
+# snapshot state.
 
 _GTR_TRUST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
 
-# Read all hook definitions from a .gtrconfig file.
+# Read all trusted command definitions from a .gtrconfig file.
 # Usage: _hooks_read_definitions <config_file>
 _hooks_read_definitions() {
   local config_file="$1"
   local hook_content
-  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null) || true
   [ -n "$hook_content" ] || return 1
   printf '%s\n' "$hook_content"
 }
 
-# Compute a content hash for hook definitions.
+# Compute a content hash for trusted command definitions.
 # Usage: _hooks_content_hash <hook_content>
 _hooks_content_hash() {
   local hook_content="$1"
@@ -30,7 +32,7 @@ _hooks_content_hash() {
   printf '%s\n' "$hook_content" | shasum -a 256 | cut -d' ' -f1
 }
 
-# Compute a content hash of all current hook entries in a .gtrconfig file.
+# Compute a content hash of all current trusted command entries in a .gtrconfig file.
 # Usage: _hooks_current_content_hash <config_file>
 _hooks_current_content_hash() {
   local config_file="$1"
@@ -63,7 +65,7 @@ _hooks_canonical_config_path() {
   printf '%s/%s\n' "$repo_root" "$(basename "$config_file")"
 }
 
-# Compute the repo-scoped trust key for reviewed hook content
+# Compute the repo-scoped trust key for reviewed trusted command content
 # Usage: _hooks_reviewed_trust_key <config_file> <hook_content>
 _hooks_reviewed_trust_key() {
   local config_file="$1"
@@ -74,7 +76,7 @@ _hooks_reviewed_trust_key() {
   printf '%s\n%s\n' "$repo_root" "$hash" | shasum -a 256 | cut -d' ' -f1
 }
 
-# Compute the repo-scoped trust key for the current hook content
+# Compute the repo-scoped trust key for the current trusted command content
 # Usage: _hooks_current_trust_key <config_file>
 _hooks_current_trust_key() {
   local config_file="$1"
@@ -88,7 +90,7 @@ _hooks_trust_key() {
   _hooks_current_trust_key "$1"
 }
 
-# Resolve the trust marker path for reviewed hook content
+# Resolve the trust marker path for reviewed trusted command content
 # Usage: _hooks_reviewed_trust_path <config_file> <hook_content>
 _hooks_reviewed_trust_path() {
   local config_file="$1"
@@ -129,9 +131,9 @@ _hooks_marker_matches_config() {
   [ "$marker_content" = "$canonical_config_file" ]
 }
 
-# Check if .gtrconfig hooks are trusted for the current repository
+# Check if .gtrconfig command definitions are trusted for the current repository
 # Usage: _hooks_are_trusted <config_file>
-# Returns: 0 if trusted (or no hooks), 1 if untrusted
+# Returns: 0 if trusted (or no trusted command definitions), 1 if untrusted
 _hooks_are_trusted() {
   local config_file="$1"
   [ ! -f "$config_file" ] && return 0
@@ -142,7 +144,7 @@ _hooks_are_trusted() {
   _hooks_marker_matches_config "$trust_path" "$config_file"
 }
 
-# Write a trust marker that matches the reviewed hooks
+# Write a trust marker that matches the reviewed command definitions
 # Usage: _hooks_write_trust_marker <trust_path> [config_file]
 _hooks_write_trust_marker() {
   local trust_path="$1"
@@ -165,7 +167,7 @@ _hooks_write_trust_marker() {
   fi
 }
 
-# Mark .gtrconfig hooks as trusted
+# Mark .gtrconfig command definitions as trusted
 # Usage: _hooks_mark_trusted <config_file>
 _hooks_mark_trusted() {
   local config_file="$1"

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -1,6 +1,86 @@
 #!/usr/bin/env bash
 # Hook execution system
 
+# ── Hook trust model ────────────────────────────────────────────────────
+# Hooks from .gtrconfig files (committed to repositories) require explicit
+# user approval before execution. This prevents malicious contributors from
+# injecting arbitrary commands via shared config files.
+#
+# Trust state is stored per-repo in ~/.config/gtr/trusted/<hash>
+# where <hash> is the SHA-256 of the .gtrconfig hooks content.
+
+_GTR_TRUST_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/gtr/trusted"
+
+# Compute a content hash of all hook entries in a .gtrconfig file
+# Usage: _hooks_file_hash <config_file>
+_hooks_file_hash() {
+  local config_file="$1"
+  local hook_content
+  hook_content=$(git config -f "$config_file" --get-regexp '^hooks\.' 2>/dev/null) || true
+  if [ -z "$hook_content" ]; then
+    return 1
+  fi
+  printf '%s' "$hook_content" | shasum -a 256 | cut -d' ' -f1
+}
+
+# Check if .gtrconfig hooks are trusted for the current repository
+# Usage: _hooks_are_trusted <config_file>
+# Returns: 0 if trusted (or no hooks), 1 if untrusted
+_hooks_are_trusted() {
+  local config_file="$1"
+  [ ! -f "$config_file" ] && return 0
+
+  local hash
+  hash=$(_hooks_file_hash "$config_file") || return 0  # no hooks = trusted
+
+  [ -f "$_GTR_TRUST_DIR/$hash" ]
+}
+
+# Mark .gtrconfig hooks as trusted
+# Usage: _hooks_mark_trusted <config_file>
+_hooks_mark_trusted() {
+  local config_file="$1"
+  local hash
+  hash=$(_hooks_file_hash "$config_file") || return 0
+
+  mkdir -p "$_GTR_TRUST_DIR"
+  printf '%s\n' "$config_file" > "$_GTR_TRUST_DIR/$hash"
+}
+
+# Get hooks, filtering out untrusted .gtrconfig hooks with a warning
+# Usage: _hooks_get_trusted <phase>
+_hooks_get_trusted() {
+  local phase="$1"
+
+  # Always include hooks from git config (user controls their own .git/config)
+  local git_hooks
+  git_hooks=$(git config --get-all "gtr.hook.$phase" 2>/dev/null) || true
+
+  # Check .gtrconfig trust before including its hooks
+  local config_file
+  config_file=$(_gtrconfig_path)
+  local file_hooks=""
+
+  if [ -n "$config_file" ] && [ -f "$config_file" ]; then
+    if _hooks_are_trusted "$config_file"; then
+      file_hooks=$(git config -f "$config_file" --get-all "hooks.$phase" 2>/dev/null) || true
+    else
+      local untrusted_hooks
+      untrusted_hooks=$(git config -f "$config_file" --get-all "hooks.$phase" 2>/dev/null) || true
+      if [ -n "$untrusted_hooks" ]; then
+        log_warn "Untrusted .gtrconfig hooks for '$phase' phase — skipping"
+        log_warn "Review hooks in $config_file, then run: git gtr trust"
+      fi
+    fi
+  fi
+
+  # Merge and deduplicate
+  {
+    [ -n "$git_hooks" ] && printf '%s\n' "$git_hooks"
+    [ -n "$file_hooks" ] && printf '%s\n' "$file_hooks"
+  } | awk '!seen[$0]++'
+}
+
 # Run hooks for a specific phase
 # Usage: run_hooks phase [env_vars...]
 # Example: run_hooks postCreate REPO_ROOT="$root" WORKTREE_PATH="$path"
@@ -8,9 +88,9 @@ run_hooks() {
   local phase="$1"
   shift
 
-  # Get hooks from git config and .gtrconfig file
+  # Get hooks, filtering untrusted .gtrconfig hooks
   local hooks
-  hooks=$(cfg_get_all "gtr.hook.$phase" "hooks.$phase")
+  hooks=$(_hooks_get_trusted "$phase")
 
   if [ -z "$hooks" ]; then
     # No hooks configured for this phase
@@ -95,7 +175,7 @@ run_hooks_export() {
   shift
 
   local hooks
-  hooks=$(cfg_get_all "gtr.hook.$phase" "hooks.$phase")
+  hooks=$(_hooks_get_trusted "$phase")
 
   if [ -z "$hooks" ]; then
     return 0

--- a/lib/launch.sh
+++ b/lib/launch.sh
@@ -5,11 +5,11 @@
 
 # Config default helpers — single source of truth for editor/AI config keys
 _cfg_editor_default() {
-  cfg_default gtr.editor.default GTR_EDITOR_DEFAULT "none" defaults.editor
+  cfg_default_trusted_file gtr.editor.default GTR_EDITOR_DEFAULT "none" defaults.editor
 }
 
 _cfg_ai_default() {
-  cfg_default gtr.ai.default GTR_AI_DEFAULT "none" defaults.ai
+  cfg_default_trusted_file gtr.ai.default GTR_AI_DEFAULT "none" defaults.ai
 }
 
 # Open a worktree in an editor (shared by _auto_launch_editor and cmd_editor)

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -126,32 +126,52 @@ spawn_terminal_in() {
       fi
       ;;
     linux)
-      # Escape cmd and path for safe embedding in sh -c strings
-      local safe_sh_cmd safe_sh_path
-      safe_sh_cmd=$(printf '%q' "$cmd")
-      safe_sh_path=$(printf '%q' "$path")
+      local shell_after="${SHELL:-/bin/sh}"
+      # shellcheck disable=SC2016 # The script is intentionally evaluated by sh in the new terminal.
+      local terminal_script='cd "$1" || exit 1
+shift
+if [ "$#" -gt 0 ]; then
+  "$@"
+fi
+exec "$SHELL_AFTER"'
       # Try common terminal emulators
       if command -v gnome-terminal >/dev/null 2>&1; then
-        gnome-terminal --working-directory="$path" --title="$title" -- sh -c "$safe_sh_cmd; exec \$SHELL" 2>/dev/null || true
+        if [ -n "$cmd" ]; then
+          gnome-terminal --working-directory="$path" --title="$title" -- env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" bash -lc "$cmd" 2>/dev/null || true
+        else
+          gnome-terminal --working-directory="$path" --title="$title" -- env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" 2>/dev/null || true
+        fi
       elif command -v konsole >/dev/null 2>&1; then
-        konsole --workdir "$path" -p "tabtitle=$title" -e sh -c "$safe_sh_cmd; exec \$SHELL" 2>/dev/null || true
+        if [ -n "$cmd" ]; then
+          konsole --workdir "$path" -p "tabtitle=$title" -e env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" bash -lc "$cmd" 2>/dev/null || true
+        else
+          konsole --workdir "$path" -p "tabtitle=$title" -e env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" 2>/dev/null || true
+        fi
       elif command -v xterm >/dev/null 2>&1; then
-        xterm -T "$title" -e "cd $safe_sh_path && $safe_sh_cmd && exec \$SHELL" 2>/dev/null || true
+        if [ -n "$cmd" ]; then
+          xterm -T "$title" -e env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" bash -lc "$cmd" 2>/dev/null || true
+        else
+          xterm -T "$title" -e env SHELL_AFTER="$shell_after" sh -c "$terminal_script" sh "$path" 2>/dev/null || true
+        fi
       else
         log_warn "No supported terminal emulator found"
         return 1
       fi
       ;;
     windows)
-      # Escape for safe embedding in cmd.exe strings
-      local safe_win_cmd safe_win_path
-      safe_win_cmd=$(printf '%q' "$cmd")
-      safe_win_path=$(printf '%q' "$path")
       # Try Windows Terminal, then fallback to cmd
       if command -v wt >/dev/null 2>&1; then
-        wt -d "$path" "$cmd" 2>/dev/null || true
+        if [ -n "$cmd" ]; then
+          wt -d "$path" cmd.exe /k "$cmd" 2>/dev/null || true
+        else
+          wt -d "$path" 2>/dev/null || true
+        fi
       else
-        cmd.exe /c start "$title" cmd.exe /k "cd /d $safe_win_path && $safe_win_cmd" 2>/dev/null || true
+        if [ -n "$cmd" ]; then
+          cmd.exe /c start "$title" cmd.exe /k "cd /d \"$path\" && $cmd" 2>/dev/null || true
+        else
+          cmd.exe /c start "$title" cmd.exe /k "cd /d \"$path\"" 2>/dev/null || true
+        fi
       fi
       ;;
     *)

--- a/lib/platform.sh
+++ b/lib/platform.sh
@@ -126,24 +126,32 @@ spawn_terminal_in() {
       fi
       ;;
     linux)
+      # Escape cmd and path for safe embedding in sh -c strings
+      local safe_sh_cmd safe_sh_path
+      safe_sh_cmd=$(printf '%q' "$cmd")
+      safe_sh_path=$(printf '%q' "$path")
       # Try common terminal emulators
       if command -v gnome-terminal >/dev/null 2>&1; then
-        gnome-terminal --working-directory="$path" --title="$title" -- sh -c "$cmd; exec \$SHELL" 2>/dev/null || true
+        gnome-terminal --working-directory="$path" --title="$title" -- sh -c "$safe_sh_cmd; exec \$SHELL" 2>/dev/null || true
       elif command -v konsole >/dev/null 2>&1; then
-        konsole --workdir "$path" -p "tabtitle=$title" -e sh -c "$cmd; exec \$SHELL" 2>/dev/null || true
+        konsole --workdir "$path" -p "tabtitle=$title" -e sh -c "$safe_sh_cmd; exec \$SHELL" 2>/dev/null || true
       elif command -v xterm >/dev/null 2>&1; then
-        xterm -T "$title" -e "cd \"$path\" && $cmd && exec \$SHELL" 2>/dev/null || true
+        xterm -T "$title" -e "cd $safe_sh_path && $safe_sh_cmd && exec \$SHELL" 2>/dev/null || true
       else
         log_warn "No supported terminal emulator found"
         return 1
       fi
       ;;
     windows)
+      # Escape for safe embedding in cmd.exe strings
+      local safe_win_cmd safe_win_path
+      safe_win_cmd=$(printf '%q' "$cmd")
+      safe_win_path=$(printf '%q' "$path")
       # Try Windows Terminal, then fallback to cmd
       if command -v wt >/dev/null 2>&1; then
         wt -d "$path" "$cmd" 2>/dev/null || true
       else
-        cmd.exe /c start "$title" cmd.exe /k "cd /d \"$path\" && $cmd" 2>/dev/null || true
+        cmd.exe /c start "$title" cmd.exe /k "cd /d $safe_win_path && $safe_win_cmd" 2>/dev/null || true
       fi
       ;;
     *)

--- a/lib/ui.sh
+++ b/lib/ui.sh
@@ -140,7 +140,7 @@ prompt_input() {
   read -r input
 
   if [ -n "$var_name" ]; then
-    eval "$var_name=\"\$input\""
+    printf -v "$var_name" '%s' "$input"
   else
     printf "%s" "$input"
   fi

--- a/scripts/generate-completions.sh
+++ b/scripts/generate-completions.sh
@@ -304,7 +304,7 @@ _git-gtr() {
     'config:Manage configuration'
     'completion:Generate shell completions'
     'init:Generate shell integration for cd support'
-    'trust:Trust .gtrconfig hooks'
+    'trust:Trust .gtrconfig commands'
     'version:Show version'
     'help:Show help'
   )
@@ -532,7 +532,7 @@ complete -f -c git -n '__fish_git_gtr_using_command completion' -a 'bash zsh fis
 complete -f -c git -n '__fish_git_gtr_needs_command' -a init -d 'Generate shell integration for cd support'
 complete -f -c git -n '__fish_git_gtr_using_command init' -a 'bash zsh fish' -d 'Shell type'
 complete -c git -n '__fish_git_gtr_using_command init' -l as -d 'Custom function name' -r
-complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig hooks'
+complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig commands'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a version -d 'Show version'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a help -d 'Show help'
 

--- a/scripts/generate-completions.sh
+++ b/scripts/generate-completions.sh
@@ -115,7 +115,7 @@ _git_gtr() {
 
   # If we're completing the first argument after 'git gtr'
   if [ "$cword" -eq 2 ]; then
-    COMPREPLY=($(compgen -W "new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init help version" -- "$cur"))
+    COMPREPLY=($(compgen -W "new go run copy editor ai rm mv rename ls list clean doctor adapter config completion init trust help version" -- "$cur"))
     return 0
   fi
 
@@ -304,6 +304,7 @@ _git-gtr() {
     'config:Manage configuration'
     'completion:Generate shell completions'
     'init:Generate shell integration for cd support'
+    'trust:Trust .gtrconfig hooks'
     'version:Show version'
     'help:Show help'
   )
@@ -529,6 +530,7 @@ complete -f -c git -n '__fish_git_gtr_using_command completion' -a 'bash zsh fis
 complete -f -c git -n '__fish_git_gtr_needs_command' -a init -d 'Generate shell integration for cd support'
 complete -f -c git -n '__fish_git_gtr_using_command init' -a 'bash zsh fish' -d 'Shell type'
 complete -c git -n '__fish_git_gtr_using_command init' -l as -d 'Custom function name' -r
+complete -f -c git -n '__fish_git_gtr_needs_command' -a trust -d 'Trust .gtrconfig hooks'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a version -d 'Show version'
 complete -f -c git -n '__fish_git_gtr_needs_command' -a help -d 'Show help'
 

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -141,6 +141,34 @@ EOF
   [ "$GTR_AI_CMD_NAME" = "bunx" ]
 }
 
+@test "_load_adapter allows path-like literal arguments" {
+  mock_bin_dir="$(mktemp -d)"
+  cat > "$mock_bin_dir/tool" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/tool"
+  PATH="$mock_bin_dir:$PATH"
+
+  _load_adapter "ai" "tool ~/.toolrc ../config/local.yml" "AI tool" "$(_list_registry_names "$_AI_REGISTRY")" "tool"
+  [ "$GTR_AI_CMD" = "tool ~/.toolrc ../config/local.yml" ]
+  [ "$GTR_AI_CMD_NAME" = "tool" ]
+}
+
+@test "_load_adapter allows raw metacharacters inside literal argv data" {
+  mock_bin_dir="$(mktemp -d)"
+  cat > "$mock_bin_dir/tool" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/tool"
+  PATH="$mock_bin_dir:$PATH"
+
+  _load_adapter "ai" "tool --label foo&bar" "AI tool" "$(_list_registry_names "$_AI_REGISTRY")" "tool"
+  [ "$GTR_AI_CMD" = "tool --label foo&bar" ]
+  [ "$GTR_AI_CMD_NAME" = "tool" ]
+}
+
 @test "_load_adapter rejects filesystem path commands in generic fallback" {
   run _load_adapter "editor" "./bin/gtr" "Editor" "$(_list_registry_names "$_EDITOR_REGISTRY")" "code, vim"
   [ "$status" -eq 1 ]

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -159,6 +159,7 @@ EOF
 
 @test "override AI adapters preserve configured flags" {
   export HOME="$BATS_TMPDIR/home"
+  PATH="/usr/bin:/bin"
   mkdir -p "$HOME/.claude/local" "$BATS_TMPDIR/worktree"
   cat > "$HOME/.claude/local/claude" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -151,8 +151,21 @@ EOF
   [ "$status" -eq 1 ]
 }
 
-@test "_run_configured_command preserves quoted arguments" {
-  run _run_configured_command "printf '%s\n' 'hello world'"
+@test "_parse_configured_command writes caller-owned argv without shell evaluation" {
+  local -a parsed_argv=()
+  _parse_configured_command parsed_argv "printf '%s\n' 'hello world'"
+
+  [ "${#parsed_argv[@]}" -eq 3 ]
+  [ "${parsed_argv[0]}" = "printf" ]
+  [ "${parsed_argv[1]}" = "%s\n" ]
+  [ "${parsed_argv[2]}" = "hello world" ]
+}
+
+@test "_run_configured_command preserves quoted arguments from parsed argv" {
+  local -a parsed_argv=()
+  _parse_configured_command parsed_argv "printf '%s\n' 'hello world'"
+
+  run _run_configured_command "${parsed_argv[@]}"
   [ "$status" -eq 0 ]
   [ "$output" = "hello world" ]
 }

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -146,8 +146,44 @@ EOF
   [ "$status" -eq 1 ]
 }
 
+@test "_load_adapter rejects shell wrapper commands in generic fallback" {
+  run _load_adapter "ai" 'sh -c "printf injected"' "AI tool" "$(_list_registry_names "$_AI_REGISTRY")" "bunx, gpt"
+  [ "$status" -eq 1 ]
+}
+
 @test "_run_configured_command preserves quoted arguments" {
   run _run_configured_command "printf '%s\n' 'hello world'"
   [ "$status" -eq 0 ]
   [ "$output" = "hello world" ]
+}
+
+@test "override AI adapters preserve configured flags" {
+  export HOME="$BATS_TMPDIR/home"
+  mkdir -p "$HOME/.claude/local" "$BATS_TMPDIR/worktree"
+  cat > "$HOME/.claude/local/claude" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$BATS_TMPDIR/claude-args"
+EOF
+  chmod +x "$HOME/.claude/local/claude"
+
+  load_ai_adapter "claude --continue"
+  ai_start "$BATS_TMPDIR/worktree" --resume
+
+  [ "$(cat "$BATS_TMPDIR/claude-args")" = "--continue --resume" ]
+}
+
+@test "override editor adapters preserve configured flags" {
+  mock_bin_dir="$(mktemp -d)"
+  mkdir -p "$BATS_TMPDIR/project"
+  cat > "$mock_bin_dir/nano" <<'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$(pwd)" "$*" > "$BATS_TMPDIR/nano-call"
+EOF
+  chmod +x "$mock_bin_dir/nano"
+  PATH="$mock_bin_dir:$PATH"
+
+  load_editor_adapter "nano -w"
+  editor_open "$BATS_TMPDIR/project"
+
+  [ "$(cat "$BATS_TMPDIR/nano-call")" = "$BATS_TMPDIR/project|-w" ]
 }

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -141,6 +141,11 @@ EOF
   [ "$GTR_AI_CMD_NAME" = "bunx" ]
 }
 
+@test "_load_adapter rejects filesystem path commands in generic fallback" {
+  run _load_adapter "editor" "./bin/gtr" "Editor" "$(_list_registry_names "$_EDITOR_REGISTRY")" "code, vim"
+  [ "$status" -eq 1 ]
+}
+
 @test "_run_configured_command preserves quoted arguments" {
   run _run_configured_command "printf '%s\n' 'hello world'"
   [ "$status" -eq 0 ]

--- a/tests/adapters.bats
+++ b/tests/adapters.bats
@@ -6,7 +6,14 @@ setup() {
   # Adapters source needs stubs for additional functions it may reference
   resolve_workspace_file() { :; }
   export -f resolve_workspace_file
+  GTR_DIR="$PROJECT_ROOT"
   source "$PROJECT_ROOT/lib/adapters.sh"
+}
+
+teardown() {
+  if [ -n "${mock_bin_dir:-}" ]; then
+    rm -rf "$mock_bin_dir"
+  fi
 }
 
 # ── _registry_lookup ─────────────────────────────────────────────────────────
@@ -118,4 +125,24 @@ setup() {
   [ "$_AI_CMD" = "codex" ]
   # codex has semicolon-separated info lines (e.g., "Or: brew install codex;See https://...")
   [ "${#_AI_INFO_LINES[@]}" -ge 2 ]
+}
+
+@test "_load_adapter allows generic commands with slash-bearing arguments" {
+  mock_bin_dir="$(mktemp -d)"
+  cat > "$mock_bin_dir/bunx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/bunx"
+  PATH="$mock_bin_dir:$PATH"
+
+  _load_adapter "ai" "bunx @github/copilot@latest" "AI tool" "$(_list_registry_names "$_AI_REGISTRY")" "bunx, gpt"
+  [ "$GTR_AI_CMD" = "bunx @github/copilot@latest" ]
+  [ "$GTR_AI_CMD_NAME" = "bunx" ]
+}
+
+@test "_run_configured_command preserves quoted arguments" {
+  run _run_configured_command "printf '%s\n' 'hello world'"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello world" ]
 }

--- a/tests/cmd_trust.bats
+++ b/tests/cmd_trust.bats
@@ -33,7 +33,7 @@ EOF
 EOF
 
   prompt_yes_no() { return 0; }
-  _hooks_mark_trusted() { return 1; }
+  _hooks_write_trust_marker() { return 1; }
 
   local output_file="$BATS_TMPDIR/cmd-trust-failure.out"
   local rc=0
@@ -45,4 +45,61 @@ EOF
 
   [ "$rc" -eq 1 ]
   grep -F "Failed to mark hooks as trusted" "$output_file"
+}
+
+@test "cmd_trust trusts the reviewed snapshot and fails if hooks change during confirmation" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo reviewed
+EOF
+
+  local reviewed_trust_path
+  reviewed_trust_path=$(_hooks_trust_path "$TEST_REPO/.gtrconfig")
+
+  prompt_yes_no() {
+    cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo changed
+EOF
+    return 0
+  }
+
+  local output_file="$BATS_TMPDIR/cmd-trust-changed.out"
+  local rc=0
+  if cmd_trust >"$output_file" 2>&1; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  [ "$rc" -eq 1 ]
+  [ -f "$reviewed_trust_path" ]
+  ! _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+  grep -F "Hooks changed during review; current hooks remain untrusted" "$output_file"
+}
+
+@test "cmd_trust writes the reviewed marker when hooks change during confirmation" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo original
+EOF
+
+  local reviewed_marker
+  reviewed_marker="$(_hooks_trust_path "$TEST_REPO/.gtrconfig")"
+
+  prompt_yes_no() {
+    cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo changed
+EOF
+    return 0
+  }
+
+  run cmd_trust
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Hooks changed during review; current hooks remain untrusted"* ]]
+  [ -f "$reviewed_marker" ]
+
+  run _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+  [ "$status" -eq 1 ]
 }

--- a/tests/cmd_trust.bats
+++ b/tests/cmd_trust.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  setup_integration_repo
+  export XDG_CONFIG_HOME="$BATS_TMPDIR/gtr-trust-config-$$"
+  source_gtr_commands
+}
+
+teardown() {
+  rm -rf "$XDG_CONFIG_HOME"
+  teardown_integration_repo
+}
+
+@test "cmd_trust marks hooks as trusted after confirmation" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  prompt_yes_no() { return 0; }
+
+  run cmd_trust
+  [ "$status" -eq 0 ]
+  _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+}
+
+@test "cmd_trust returns an error when the trust marker cannot be written" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  prompt_yes_no() { return 0; }
+  _hooks_mark_trusted() { return 1; }
+
+  local output_file="$BATS_TMPDIR/cmd-trust-failure.out"
+  local rc=0
+  if cmd_trust >"$output_file" 2>&1; then
+    rc=0
+  else
+    rc=$?
+  fi
+
+  [ "$rc" -eq 1 ]
+  grep -F "Failed to mark hooks as trusted" "$output_file"
+}

--- a/tests/cmd_trust.bats
+++ b/tests/cmd_trust.bats
@@ -13,10 +13,12 @@ teardown() {
   teardown_integration_repo
 }
 
-@test "cmd_trust marks hooks as trusted after confirmation" {
+@test "cmd_trust marks executable commands as trusted after confirmation" {
   cat > "$TEST_REPO/.gtrconfig" <<'EOF'
 [hooks]
   postCd = echo hi
+[defaults]
+  ai = claude
 EOF
 
   prompt_yes_no() { return 0; }
@@ -44,7 +46,7 @@ EOF
   fi
 
   [ "$rc" -eq 1 ]
-  grep -F "Failed to mark hooks as trusted" "$output_file"
+  grep -F "Failed to mark executable commands as trusted" "$output_file"
 }
 
 @test "cmd_trust trusts the reviewed snapshot and fails if hooks change during confirmation" {
@@ -75,7 +77,7 @@ EOF
   [ "$rc" -eq 1 ]
   [ -f "$reviewed_trust_path" ]
   ! _hooks_are_trusted "$TEST_REPO/.gtrconfig"
-  grep -F "Hooks changed during review; current hooks remain untrusted" "$output_file"
+  grep -F "Executable commands changed during review; current commands remain untrusted" "$output_file"
 }
 
 @test "cmd_trust writes the reviewed marker when hooks change during confirmation" {
@@ -97,7 +99,7 @@ EOF
 
   run cmd_trust
   [ "$status" -eq 1 ]
-  [[ "$output" == *"Hooks changed during review; current hooks remain untrusted"* ]]
+  [[ "$output" == *"Executable commands changed during review; current commands remain untrusted"* ]]
   [ -f "$reviewed_marker" ]
 
   run _hooks_are_trusted "$TEST_REPO/.gtrconfig"

--- a/tests/copy_safety.bats
+++ b/tests/copy_safety.bats
@@ -181,3 +181,25 @@ teardown() {
   [ -f "$dst/CLAUDE.md" ]
   [ -f "$dst/config/CLAUDE.md" ]
 }
+
+@test "_apply_directory_excludes supports node_modules/* patterns" {
+  _test_tmpdir=$(mktemp -d)
+  local dest="$_test_tmpdir/dest"
+  mkdir -p "$dest/node_modules/.cache"
+  touch "$dest/node_modules/.cache/file"
+
+  _apply_directory_excludes "$dest" "node_modules" $'node_modules/*'
+
+  [ ! -e "$dest/node_modules/.cache" ]
+}
+
+@test "_apply_directory_excludes skips patterns targeting .git metadata" {
+  _test_tmpdir=$(mktemp -d)
+  local dest="$_test_tmpdir/dest"
+  mkdir -p "$dest/node_modules/.git"
+  touch "$dest/node_modules/.git/config"
+
+  _apply_directory_excludes "$dest" "node_modules" $'node_modules/.git'
+
+  [ -e "$dest/node_modules/.git" ]
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -26,7 +26,19 @@ teardown() {
 EOF
 
   local expected
-  expected="$(git config -f "$TEST_REPO/.gtrconfig" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+  expected="$(git config -f "$TEST_REPO/.gtrconfig" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+
+  [ "$(_hooks_file_hash "$TEST_REPO/.gtrconfig")" = "$expected" ]
+}
+
+@test "_hooks_file_hash includes executable defaults" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  ai = npx --package=./malicious evilbin
+EOF
+
+  local expected
+  expected="$(git config -f "$TEST_REPO/.gtrconfig" --get-regexp '^hooks\.|^defaults\.editor$|^defaults\.ai$' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
 
   [ "$(_hooks_file_hash "$TEST_REPO/.gtrconfig")" = "$expected" ]
 }
@@ -56,13 +68,23 @@ EOF
   [ "$status" -eq 1 ]
 }
 
-@test "_hooks_are_trusted treats configs without hooks as trusted" {
+@test "_hooks_are_trusted treats configs without trusted command definitions as trusted" {
   cat > "$TEST_REPO/.gtrconfig" <<'EOF'
 [copy]
   include = .env
 EOF
 
   _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+}
+
+@test "_hooks_are_trusted requires trust for executable defaults" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  editor = npx --package=./malicious evilbin
+EOF
+
+  run _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+  [ "$status" -eq 1 ]
 }
 
 @test "_hooks_are_trusted fails closed when trust path resolution errors" {

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -5,16 +5,40 @@ load test_helper
 
 setup() {
   setup_integration_repo
+  export XDG_CONFIG_HOME="$BATS_TMPDIR/gtr-hooks-config-$$"
   source_gtr_libs
 }
 
 teardown() {
+  rm -rf "$XDG_CONFIG_HOME"
   teardown_integration_repo
 }
 
 @test "run_hooks returns 0 when no hooks configured" {
   run run_hooks postCreate REPO_ROOT="$TEST_REPO"
   [ "$status" -eq 0 ]
+}
+
+@test "_hooks_file_hash matches the init wrapper trust hash" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  local expected
+  expected="$(git config -f "$TEST_REPO/.gtrconfig" --get-regexp '^hooks\.' 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+
+  [ "$(_hooks_file_hash "$TEST_REPO/.gtrconfig")" = "$expected" ]
+}
+
+@test "_hooks_mark_trusted creates a marker recognized by _hooks_are_trusted" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  _hooks_mark_trusted "$TEST_REPO/.gtrconfig"
+  _hooks_are_trusted "$TEST_REPO/.gtrconfig"
 }
 
 @test "run_hooks executes single hook" {

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -41,6 +41,21 @@ EOF
   _hooks_are_trusted "$TEST_REPO/.gtrconfig"
 }
 
+@test "_hooks_are_trusted rejects empty trust marker files" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  local trust_path
+  trust_path="$(_hooks_trust_path "$TEST_REPO/.gtrconfig")"
+  mkdir -p "$(dirname "$trust_path")"
+  : > "$trust_path"
+
+  run _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+  [ "$status" -eq 1 ]
+}
+
 @test "repo-specific trust markers differ for the same hook content" {
   local second_repo="$BATS_TMPDIR/second-repo"
   mkdir -p "$second_repo"

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -56,6 +56,37 @@ EOF
   [ "$status" -eq 1 ]
 }
 
+@test "_hooks_are_trusted treats configs without hooks as trusted" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[copy]
+  include = .env
+EOF
+
+  _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+}
+
+@test "_hooks_are_trusted fails closed when trust path resolution errors" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  _hooks_reviewed_trust_path() { return 1; }
+
+  ! _hooks_are_trusted "$TEST_REPO/.gtrconfig"
+}
+
+@test "_hooks_mark_trusted fails when trust path resolution errors" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = echo hi
+EOF
+
+  _hooks_reviewed_trust_path() { return 1; }
+
+  ! _hooks_mark_trusted "$TEST_REPO/.gtrconfig"
+}
+
 @test "repo-specific trust markers differ for the same hook content" {
   local second_repo="$BATS_TMPDIR/second-repo"
   mkdir -p "$second_repo"

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -41,6 +41,27 @@ EOF
   _hooks_are_trusted "$TEST_REPO/.gtrconfig"
 }
 
+@test "repo-specific trust markers differ for the same hook content" {
+  local second_repo="$BATS_TMPDIR/second-repo"
+  mkdir -p "$second_repo"
+
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = ./scripts/bootstrap
+EOF
+
+  cat > "$second_repo/.gtrconfig" <<'EOF'
+[hooks]
+  postCd = ./scripts/bootstrap
+EOF
+
+  local first_path second_path
+  first_path="$(_hooks_trust_path "$TEST_REPO/.gtrconfig")"
+  second_path="$(_hooks_trust_path "$second_repo/.gtrconfig")"
+
+  [ "$first_path" != "$second_path" ]
+}
+
 @test "run_hooks executes single hook" {
   git config --add gtr.hook.postCreate 'touch "$REPO_ROOT/hook-ran"'
   run_hooks postCreate REPO_ROOT="$TEST_REPO"

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -179,10 +179,23 @@ BASH
   [[ "$output" == *'"cd new go run'* ]]
 }
 
+@test "bash output includes trust in subcommand completions" {
+  run cmd_init bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'init trust help version'* ]]
+}
+
 @test "bash output uses git gtr list --porcelain for cd completion" {
   run cmd_init bash
   [ "$status" -eq 0 ]
   [[ "$output" == *"git gtr list --porcelain"* ]]
+}
+
+@test "generated wrappers resolve .gtrconfig from the git common dir" {
+  run cmd_init bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"git rev-parse --git-common-dir"* ]]
+  [[ "$output" == *'printf '\''%s/.gtrconfig\n'\'''* ]]
 }
 
 @test "zsh output includes cd completion" {
@@ -697,6 +710,19 @@ BASH
   [ "$status" -eq 0 ]
   stamp="$(head -1 "$XDG_CACHE_HOME/gtr/init-gtr.zsh")"
   [[ "$stamp" == *"version=2.0.0"* ]]
+}
+
+@test "cache invalidates when shell integration schema changes" {
+  GTR_INIT_CACHE_VERSION="1" run cmd_init bash
+  [ "$status" -eq 0 ]
+  local stamp
+  stamp="$(head -1 "$XDG_CACHE_HOME/gtr/init-gtr.bash")"
+  [[ "$stamp" == *"init=1"* ]]
+
+  GTR_INIT_CACHE_VERSION="2" run cmd_init bash
+  [ "$status" -eq 0 ]
+  stamp="$(head -1 "$XDG_CACHE_HOME/gtr/init-gtr.bash")"
+  [[ "$stamp" == *"init=2"* ]]
 }
 
 @test "cache uses --as func name in cache key" {

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -201,15 +201,16 @@ BASH
 @test "generated wrappers scope trust markers by repo root" {
   run cmd_init bash
   [ "$status" -eq 0 ]
-  [[ "$output" == *"hooks_trust_key"* ]]
-  [[ "$output" == *'dirname "$_gtr_config_file"'* ]]
+  [[ "$output" == *"hooks_current_trust_key"* ]]
+  [[ "$output" == *"hooks_repo_root"* ]]
 }
 
 @test "generated wrappers validate trust marker contents" {
   run cmd_init bash
   [ "$status" -eq 0 ]
-  [[ "$output" == *"hooks_trusted"* ]]
-  [[ "$output" == *'cat "$_gtr_trust_dir/$_gtr_trust_key"'* ]]
+  [[ "$output" == *"hooks_marker_matches_config"* ]]
+  [[ "$output" == *"hooks_are_trusted"* ]]
+  [[ "$output" == *'cat "$_gtr_trust_path"'* ]]
 }
 
 @test "zsh output includes cd completion" {
@@ -222,6 +223,14 @@ BASH
   run cmd_init zsh
   [ "$status" -eq 0 ]
   [[ "$output" == *"git gtr list --porcelain"* ]]
+}
+
+@test "zsh output validates trust marker contents" {
+  run cmd_init zsh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hooks_canonical_config_path"* ]]
+  [[ "$output" == *"hooks_marker_matches_config"* ]]
+  [[ "$output" == *'cat "$_gtr_trust_path"'* ]]
 }
 
 @test "fish output includes cd subcommand completion" {
@@ -240,6 +249,14 @@ BASH
   run cmd_init fish
   [ "$status" -eq 0 ]
   [[ "$output" == *"git gtr list --porcelain"* ]]
+}
+
+@test "fish output validates trust marker contents" {
+  run cmd_init fish
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hooks_canonical_config_path"* ]]
+  [[ "$output" == *"hooks_marker_matches_config"* ]]
+  [[ "$output" == *'cat "$_gtr_trust_path"'* ]]
 }
 
 # ── new --cd wrapper support ────────────────────────────────────────────────

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -305,6 +305,21 @@ require_runtime_shell() {
   [[ "$output" == *'cat "$_gtr_trust_path"'* ]]
 }
 
+@test "fish output strips linked-worktree git common dir suffix" {
+  require_runtime_shell fish
+
+  run cmd_init fish
+  [ "$status" -eq 0 ]
+
+  local pattern
+  pattern=$(printf '%s\n' "$output" | sed -n "s/.*string replace -r '\([^']*\)'.*/\1/p" | head -n 1)
+  [ "$pattern" = '/\.git$' ]
+
+  run fish -c 'string replace -r -- $argv[1] "" /tmp/repo/.git' -- "$pattern"
+  [ "$status" -eq 0 ]
+  [ "$output" = "/tmp/repo" ]
+}
+
 # ── new --cd wrapper support ────────────────────────────────────────────────
 
 @test "bash output intercepts new --cd and strips flag before delegating" {

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -205,6 +205,13 @@ BASH
   [[ "$output" == *'dirname "$_gtr_config_file"'* ]]
 }
 
+@test "generated wrappers validate trust marker contents" {
+  run cmd_init bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hooks_trusted"* ]]
+  [[ "$output" == *'cat "$_gtr_trust_dir/$_gtr_trust_key"'* ]]
+}
+
 @test "zsh output includes cd completion" {
   run cmd_init zsh
   [ "$status" -eq 0 ]

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -110,6 +110,71 @@ printf '\n'
 SCRIPT
 }
 
+run_generated_fish_gtrconfig_post_cd_hooks() {
+  local trust_state="$1"
+  local root repo wt xdg init_file
+
+  root=$(mktemp -d)
+  repo="$root/repo"
+  wt="$root/wt"
+  xdg="$root/xdg"
+  init_file="$root/gtr.fish"
+
+  git init --quiet "$repo"
+  git -C "$repo" config user.name "Test User"
+  git -C "$repo" config user.email "test@example.com"
+  git -C "$repo" commit --allow-empty -m "init" --quiet
+  git -C "$repo" worktree add --quiet "$wt" -b feature
+
+  cat > "$repo/.gtrconfig" <<'CFG'
+[hooks]
+  postCd = pwd > "$WORKTREE_PATH/hook-pwd"
+  postCd = echo second >> "$WORKTREE_PATH/hook-order"
+[defaults]
+  ai = codex
+CFG
+
+  cmd_init fish > "$init_file"
+
+  if [ "$trust_state" = "trusted" ]; then
+    (
+      export XDG_CONFIG_HOME="$xdg"
+      # shellcheck disable=SC1091
+      . "$PROJECT_ROOT/lib/hooks.sh"
+      _hooks_mark_trusted "$repo/.gtrconfig"
+    )
+  fi
+
+  XDG_CONFIG_HOME="$xdg" fish -c '
+    source "$argv[1]"
+    set -l wt "$argv[2]"
+    set -l root "$argv[3]"
+
+    cd /
+    gtr_run_post_cd_hooks "$wt" > "$root/stdout" 2> "$root/stderr"
+    set -l rc $status
+
+    printf "RC=%s\n" "$rc"
+    printf "PWD=%s\n" "$PWD"
+    printf "WT=%s\n" "$wt"
+    if test -f "$wt/hook-pwd"
+      printf "HOOK_PWD=%s\n" (cat "$wt/hook-pwd")
+    else
+      printf "HOOK_PWD=<missing>\n"
+    end
+    if test -f "$wt/hook-order"
+      printf "HOOK_ORDER=%s\n" (paste -sd, "$wt/hook-order")
+    else
+      printf "HOOK_ORDER=<missing>\n"
+    end
+    printf "STDERR=%s\n" (cat "$root/stderr")
+  ' -- "$init_file" "$wt" "$root"
+  local rc=$?
+
+  rm -rf "$root"
+  return "$rc"
+}
+
 require_runtime_shell() {
   local shell_name="$1"
 
@@ -318,6 +383,41 @@ require_runtime_shell() {
   run fish -c 'string replace -r -- $argv[1] "" /tmp/repo/.git' -- "$pattern"
   [ "$status" -eq 0 ]
   [ "$output" = "/tmp/repo" ]
+}
+
+@test "fish generated postCd skips untrusted gtrconfig hooks without changing cwd" {
+  require_runtime_shell fish
+
+  run run_generated_fish_gtrconfig_post_cd_hooks untrusted
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RC=0"* ]]
+  [[ "$output" == *"HOOK_PWD=<missing>"* ]]
+  [[ "$output" == *"HOOK_ORDER=<missing>"* ]]
+  [[ "$output" == *"STDERR=gtr: Untrusted .gtrconfig hooks skipped"* ]]
+
+  local pwd_line wt_line
+  pwd_line=$(printf '%s\n' "$output" | sed -n 's/^PWD=//p')
+  wt_line=$(printf '%s\n' "$output" | sed -n 's/^WT=//p')
+  [ "$pwd_line" = "$wt_line" ]
+}
+
+@test "fish generated postCd trusts multi-entry gtrconfig hooks without changing cwd" {
+  require_runtime_shell fish
+
+  run run_generated_fish_gtrconfig_post_cd_hooks trusted
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RC=0"* ]]
+  [[ "$output" == *"HOOK_ORDER=second"* ]]
+  [[ "$output" == *"STDERR="* ]]
+
+  local pwd_line wt_line hook_pwd_line
+  pwd_line=$(printf '%s\n' "$output" | sed -n 's/^PWD=//p')
+  wt_line=$(printf '%s\n' "$output" | sed -n 's/^WT=//p')
+  hook_pwd_line=$(printf '%s\n' "$output" | sed -n 's/^HOOK_PWD=//p')
+  [ "$pwd_line" = "$wt_line" ]
+  [ "$hook_pwd_line" = "$wt_line" ]
 }
 
 # ── new --cd wrapper support ────────────────────────────────────────────────

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -198,6 +198,13 @@ BASH
   [[ "$output" == *'printf '\''%s/.gtrconfig\n'\'''* ]]
 }
 
+@test "generated wrappers scope trust markers by repo root" {
+  run cmd_init bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hooks_trust_key"* ]]
+  [[ "$output" == *'dirname "$_gtr_config_file"'* ]]
+}
+
 @test "zsh output includes cd completion" {
   run cmd_init zsh
   [ "$status" -eq 0 ]
@@ -214,6 +221,12 @@ BASH
   run cmd_init fish
   [ "$status" -eq 0 ]
   [[ "$output" == *"-a cd -d"* ]]
+}
+
+@test "fish output includes trust subcommand completion" {
+  run cmd_init fish
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-a trust -d"* ]]
 }
 
 @test "fish output uses git gtr list --porcelain for cd completion" {

--- a/tests/launch.bats
+++ b/tests/launch.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# Tests for lib/launch.sh config resolution
+
+load test_helper
+
+setup() {
+  setup_integration_repo
+  export XDG_CONFIG_HOME="$BATS_TMPDIR/gtr-launch-config-$$"
+  export GIT_CONFIG_GLOBAL="$BATS_TMPDIR/gtr-launch-global-$$"
+  source_gtr_commands
+}
+
+teardown() {
+  rm -rf "$XDG_CONFIG_HOME"
+  rm -f "$GIT_CONFIG_GLOBAL"
+  teardown_integration_repo
+}
+
+@test "_cfg_ai_default skips untrusted .gtrconfig defaults.ai" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  ai = npx --package=./malicious evilbin
+EOF
+
+  result=$(_cfg_ai_default)
+
+  [ "$result" = "none" ]
+}
+
+@test "_cfg_ai_default uses .gtrconfig defaults.ai after trust" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  ai = claude
+EOF
+
+  _hooks_mark_trusted "$TEST_REPO/.gtrconfig"
+
+  result=$(_cfg_ai_default)
+
+  [ "$result" = "claude" ]
+}
+
+@test "_cfg_editor_default skips untrusted .gtrconfig defaults.editor and uses global fallback" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  editor = npx --package=./malicious evilbin
+EOF
+  git config --global gtr.editor.default vim
+
+  result=$(_cfg_editor_default)
+
+  [ "$result" = "vim" ]
+}
+
+@test "_cfg_editor_default allows local config over untrusted .gtrconfig defaults.editor" {
+  cat > "$TEST_REPO/.gtrconfig" <<'EOF'
+[defaults]
+  editor = npx --package=./malicious evilbin
+EOF
+  git config --local gtr.editor.default cursor
+
+  result=$(_cfg_editor_default)
+
+  [ "$result" = "cursor" ]
+}

--- a/tests/platform.bats
+++ b/tests/platform.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  source "$PROJECT_ROOT/lib/platform.sh"
+  _platform_mock_bin="$(mktemp -d)"
+  export PATH="$_platform_mock_bin:$PATH"
+  export OSTYPE="linux-gnu"
+}
+
+teardown() {
+  rm -rf "$_platform_mock_bin"
+}
+
+@test "spawn_terminal_in passes multi-word commands as separate terminal args on linux" {
+  cat > "$_platform_mock_bin/gnome-terminal" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$@" > "$BATS_TMPDIR/gnome-terminal-args"
+EOF
+  chmod +x "$_platform_mock_bin/gnome-terminal"
+
+  run spawn_terminal_in "/tmp/work tree" "Test title" "echo hello"
+  [ "$status" -eq 0 ]
+
+  grep -Fx -- "--working-directory=/tmp/work tree" "$BATS_TMPDIR/gnome-terminal-args"
+  grep -Fx -- "--title=Test title" "$BATS_TMPDIR/gnome-terminal-args"
+  grep -Fx -- "bash" "$BATS_TMPDIR/gnome-terminal-args"
+  grep -Fx -- "-lc" "$BATS_TMPDIR/gnome-terminal-args"
+  grep -Fx -- "echo hello" "$BATS_TMPDIR/gnome-terminal-args"
+}


### PR DESCRIPTION
Supersedes #162 because maintainers cannot update that branch (`maintainerCanModify: false`).

## Summary

This PR adds a trust boundary for executable commands that come from a repository-owned `.gtrconfig`, while keeping personal git config trusted. It also removes unsafe adapter `eval` execution and tightens related filesystem/terminal handling.

## Before

- `.gtrconfig` hooks could define shell commands from shared repo config without an explicit review step.
- `.gtrconfig` `defaults.editor` / `defaults.ai` could select executable commands such as `npx --package=./malicious evilbin` before any trust prompt.
- Generic adapter command strings used `eval`, making command parsing harder to reason about.
- Trust markers were initially content-only and did not fully protect against stale/partial marker edge cases.

## After

- `git gtr trust` reviews and approves `.gtrconfig` executable command entries before use.
- `.gtrconfig` hooks, `defaults.editor`, and `defaults.ai` are ignored until trusted.
- Trust markers are scoped by repository path plus reviewed command definitions, and are rewritten only through an atomic marker path.
- Adapter commands are parsed into argv without shell evaluation; filesystem-path commands and shell wrapper forms are rejected.
- Generated Bash/Zsh/Fish init wrappers use the same trust hash inputs as runtime code.

## Evidence

- `git diff --check`
- `shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh`
- `./scripts/generate-completions.sh --check`
- `bats tests/` (443 tests)
- GitHub CI is green on head `bae5e3b`
- All review threads are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `git gtr trust` to review and approve executable commands in `.gtrconfig`; trust persists per-repo and requires re-approval on changes.

* **Improvements**
  * Trust gates local hooks and editor/AI defaults; untrusted entries are skipped with guidance to run `git gtr trust`.
  * Safer adapter handling: reject unsafe path/wrapper forms and allow adapter flags to be preserved.

* **Documentation**
  * Clarified configuration and safety rules for editor/AI defaults.

* **Tests**
  * Added extensive tests covering trust flow, adapters, shell integrations, platform, and copy-safety.

* **Chores**
  * Pinned CI actions to fixed commits and tightened workflow permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->