### PR TITLE
fix(hooks): prevent stdin drain from skipping subsequent hooks

### DIFF
--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -126,7 +126,7 @@ __FUNC___run_post_cd_hooks() {
         [ -z "$_gtr_hook" ] && continue
         case "$_gtr_seen" in *"|$_gtr_hook|"*) continue ;; esac
         _gtr_seen="$_gtr_seen|$_gtr_hook|"
-        eval "$_gtr_hook" || echo "__FUNC__: postCd hook failed: $_gtr_hook" >&2
+        eval "$_gtr_hook" </dev/null || echo "__FUNC__: postCd hook failed: $_gtr_hook" >&2
       done <<< "$_gtr_hooks"
       unset WORKTREE_PATH REPO_ROOT BRANCH
     fi
@@ -303,7 +303,7 @@ __FUNC___run_post_cd_hooks() {
         [ -z "$_gtr_hook" ] && continue
         case "$_gtr_seen" in *"|$_gtr_hook|"*) continue ;; esac
         _gtr_seen="$_gtr_seen|$_gtr_hook|"
-        eval "$_gtr_hook" || echo "__FUNC__: postCd hook failed: $_gtr_hook" >&2
+        eval "$_gtr_hook" </dev/null || echo "__FUNC__: postCd hook failed: $_gtr_hook" >&2
       done <<< "$_gtr_hooks"
       unset WORKTREE_PATH REPO_ROOT BRANCH
     fi

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -41,7 +41,7 @@ run_hooks() {
       done
       # Execute the hook
       eval "$hook"
-    ); then
+    ) </dev/null; then
       log_info "Hook $hook_count completed successfully"
     else
       local rc=$?

--- a/lib/hooks.sh
+++ b/lib/hooks.sh
@@ -118,7 +118,7 @@ run_hooks_export() {
     log_info "Hook $hook_count: $hook"
 
     # eval directly (no subshell) so exports persist
-    eval "$hook" || log_warn "Hook $hook_count failed (continuing)"
+    eval "$hook" </dev/null || log_warn "Hook $hook_count failed (continuing)"
   done <<EOF
 $hooks
 EOF

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -161,3 +161,12 @@ teardown() {
   (cd "$TEST_REPO" && run_hooks_export postCd REPO_ROOT="$TEST_REPO")
   [ -z "${LEAK_TEST:-}" ]
 }
+
+@test "run_hooks_export continues after hook that reads stdin (postCd)" {
+  git config --add gtr.hook.postCd 'echo first >> "$REPO_ROOT/order"'
+  git config --add gtr.hook.postCd 'cat'
+  git config --add gtr.hook.postCd 'echo third >> "$REPO_ROOT/order"'
+  (cd "$TEST_REPO" && run_hooks_export postCd REPO_ROOT="$TEST_REPO")
+  [ "$(head -1 "$TEST_REPO/order")" = "first" ]
+  [ "$(tail -1 "$TEST_REPO/order")" = "third" ]
+}

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -83,11 +83,29 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
-@test "run_hooks continues after hook that reads stdin" {
+@test "run_hooks continues after hook that reads stdin (postCreate)" {
   git config --add gtr.hook.postCreate 'echo first >> "$REPO_ROOT/order"'
   git config --add gtr.hook.postCreate 'cat'
   git config --add gtr.hook.postCreate 'echo third >> "$REPO_ROOT/order"'
   run_hooks postCreate REPO_ROOT="$TEST_REPO"
+  [ "$(head -1 "$TEST_REPO/order")" = "first" ]
+  [ "$(tail -1 "$TEST_REPO/order")" = "third" ]
+}
+
+@test "run_hooks continues after hook that reads stdin (preRemove)" {
+  git config --add gtr.hook.preRemove 'echo first >> "$REPO_ROOT/order"'
+  git config --add gtr.hook.preRemove 'cat'
+  git config --add gtr.hook.preRemove 'echo third >> "$REPO_ROOT/order"'
+  run_hooks preRemove REPO_ROOT="$TEST_REPO"
+  [ "$(head -1 "$TEST_REPO/order")" = "first" ]
+  [ "$(tail -1 "$TEST_REPO/order")" = "third" ]
+}
+
+@test "run_hooks continues after hook that reads stdin (postRemove)" {
+  git config --add gtr.hook.postRemove 'echo first >> "$REPO_ROOT/order"'
+  git config --add gtr.hook.postRemove 'cat'
+  git config --add gtr.hook.postRemove 'echo third >> "$REPO_ROOT/order"'
+  run_hooks postRemove REPO_ROOT="$TEST_REPO"
   [ "$(head -1 "$TEST_REPO/order")" = "first" ]
   [ "$(tail -1 "$TEST_REPO/order")" = "third" ]
 }

--- a/tests/hooks.bats
+++ b/tests/hooks.bats
@@ -83,6 +83,15 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
+@test "run_hooks continues after hook that reads stdin" {
+  git config --add gtr.hook.postCreate 'echo first >> "$REPO_ROOT/order"'
+  git config --add gtr.hook.postCreate 'cat'
+  git config --add gtr.hook.postCreate 'echo third >> "$REPO_ROOT/order"'
+  run_hooks postCreate REPO_ROOT="$TEST_REPO"
+  [ "$(head -1 "$TEST_REPO/order")" = "first" ]
+  [ "$(tail -1 "$TEST_REPO/order")" = "third" ]
+}
+
 @test "run_hooks REPO_ROOT and BRANCH env vars available" {
   git config --add gtr.hook.postCreate 'echo "$REPO_ROOT|$BRANCH" > "$REPO_ROOT/vars"'
   run_hooks postCreate REPO_ROOT="$TEST_REPO" BRANCH="test-branch"

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -110,6 +110,12 @@ printf '\n'
 SCRIPT
 }
 
+require_runtime_shell() {
+  local shell_name="$1"
+
+  command -v "$shell_name" >/dev/null 2>&1 || skip "$shell_name is not installed"
+}
+
 # ── Default function name ────────────────────────────────────────────────────
 
 @test "bash output defines gtr() function by default" {
@@ -294,6 +300,7 @@ SCRIPT
 }
 
 @test "bash generated postCd hooks continue after stdin read" {
+  require_runtime_shell bash
   run run_generated_post_cd_hooks bash
 
   [ "$status" -eq 0 ]
@@ -301,6 +308,7 @@ SCRIPT
 }
 
 @test "zsh generated postCd hooks continue after stdin read" {
+  require_runtime_shell zsh
   run run_generated_post_cd_hooks zsh
 
   [ "$status" -eq 0 ]

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -70,6 +70,46 @@ printf 'REPLY=%s\n' "${COMPREPLY[*]}"
 BASH
 }
 
+run_generated_post_cd_hooks() {
+  local shell_name="$1"
+
+  "$shell_name" -s -- "$PROJECT_ROOT" "$shell_name" <<'SCRIPT'
+PROJECT_ROOT="$1"
+shell_name="$2"
+
+log_info() { :; }
+log_warn() { :; }
+log_error() { :; }
+show_command_help() { :; }
+compdef() { :; }
+
+# shellcheck disable=SC1090
+. "$PROJECT_ROOT/lib/commands/init.sh"
+
+repo=$(mktemp -d)
+cleanup() {
+  rm -rf "$repo"
+}
+trap cleanup EXIT
+
+git -C "$repo" init --quiet
+git -C "$repo" config user.name "Test User"
+git -C "$repo" config user.email "test@example.com"
+git -C "$repo" commit --allow-empty -m "init" --quiet
+
+git -C "$repo" config --add gtr.hook.postCd 'echo first >> "$REPO_ROOT/order"'
+git -C "$repo" config --add gtr.hook.postCd 'cat'
+git -C "$repo" config --add gtr.hook.postCd 'echo third >> "$REPO_ROOT/order"'
+
+eval "$(cmd_init "$shell_name")"
+gtr_run_post_cd_hooks "$repo"
+
+printf 'ORDER='
+paste -sd, "$repo/order"
+printf '\n'
+SCRIPT
+}
+
 # ── Default function name ────────────────────────────────────────────────────
 
 @test "bash output defines gtr() function by default" {
@@ -251,6 +291,20 @@ BASH
   [[ "$output" == *"git worktree list --porcelain"* ]]
   [[ "$output" == *'run_post_cd_hooks "$_gtr_new_dir"'* ]]
   [[ "$output" == *'could not determine new directory for --cd'* ]]
+}
+
+@test "bash generated postCd hooks continue after stdin read" {
+  run run_generated_post_cd_hooks bash
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "ORDER=first,third" ]
+}
+
+@test "zsh generated postCd hooks continue after stdin read" {
+  run run_generated_post_cd_hooks zsh
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "ORDER=first,third" ]
 }
 
 @test "fish output uses worktree diff to locate the new directory for --cd" {


### PR DESCRIPTION
## Summary

Fixes #164

All hook phases (`postCreate`, `preRemove`, `postRemove`, `postCd`) suffered from the same bug: a hook that reads from stdin (e.g. `cat`, `read`) drains the hook list input, causing all subsequent hooks to be silently skipped.

- `run_hooks`: add `</dev/null` to the hook subshell `(...) </dev/null`
- `run_hooks_export`: add `</dev/null` to the `eval` call (`eval "$hook" </dev/null`)
- `init` shell integration (`bash`/`zsh`): add `</dev/null` to generated `postCd` hook execution so `git gtr cd` and `git gtr new --cd` are covered too

These changes prevent hook commands from inheriting the hook list as stdin while preserving existing behavior such as env var exports, exit code handling, and shell integration semantics.

## Test plan

- [x] Regression tests for `postCreate`, `preRemove`, and `postRemove` verify `cat` between two hooks does not skip the third
- [x] Regression test for `postCd` via `run_hooks_export`
- [x] Regression tests for generated `init` `bash`/`zsh` wrappers verify `gtr_run_post_cd_hooks` continues after a stdin-reading hook
- [x] Targeted validation passes: `bats tests/hooks.bats`
- [x] Targeted validation passes: `bats tests/init.bats`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hooks no longer consume the caller’s standard input; subsequent hooks reliably run even if an earlier hook reads stdin.

* **Tests**
  * Added tests ensuring hook execution continues across stdin-reading hooks, including post-directory-change hooks for both Bash and Zsh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
