### PR TITLE
fix(init): keep fish fzf selection in scope

### DIFF
--- a/lib/commands/init.sh
+++ b/lib/commands/init.sh
@@ -509,12 +509,14 @@ function __FUNC__
       # --expect gives two lines: key (index 1) and selection (index 2)
       # Fish collapses empty lines in command substitution, so when Enter
       # is pressed the empty key line disappears and count drops to 1.
+      set -l _gtr_key
+      set -l _gtr_line
       if test (count $_gtr_selection) -eq 1
-        set -l _gtr_key ""
-        set -l _gtr_line "$_gtr_selection[1]"
+        set _gtr_key ""
+        set _gtr_line "$_gtr_selection[1]"
       else
-        set -l _gtr_key "$_gtr_selection[1]"
-        set -l _gtr_line "$_gtr_selection[2]"
+        set _gtr_key "$_gtr_selection[1]"
+        set _gtr_line "$_gtr_selection[2]"
       end
       if test "$_gtr_key" = "ctrl-n"
         read -P "Branch name: " _gtr_branch

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -476,6 +476,17 @@ require_runtime_shell() {
   [[ "$output" == *'cd $dir'* ]]
 }
 
+@test "fish fzf enter keeps selection variables in function scope" {
+  run cmd_init fish
+  [ "$status" -eq 0 ]
+  [[ "$output" == *'set -l _gtr_key'* ]]
+  [[ "$output" == *'set -l _gtr_line'* ]]
+  [[ "$output" == *'set _gtr_key ""'* ]]
+  [[ "$output" == *'set _gtr_line "$_gtr_selection[1]"'* ]]
+  [[ "$output" != *'set -l _gtr_key ""'* ]]
+  [[ "$output" != *'set -l _gtr_line "$_gtr_selection[1]"'* ]]
+}
+
 # ── fzf: ctrl-e (editor) — via --expect ──────────────────────────────────────
 
 @test "bash fzf ctrl-e handled via --expect for full terminal access" {


### PR DESCRIPTION
## Summary

- Fix Fish shell integration so `gtr cd` fzf Enter keeps `_gtr_key` and `_gtr_line` in function scope.
- Add BATS regression coverage for the generated Fish wrapper.

Fixes #169.

## Testing

- `bats tests/init.bats`
- `bats tests/`
- `shellcheck lib/commands/init.sh`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved variable declaration logic for better code reliability and consistency.

* **Tests**
  * Added test case to verify variable scoping and assignment behavior in the initialization handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->