### PR TITLE
chore: prepare v2.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-04-27
+
+### Added
+
+- `git gtr new --remote` and `gtr.defaultRemote` / `GTR_DEFAULT_REMOTE` to choose the remote used for default branch detection, fetches, and tracked branch creation ([#171](https://github.com/coderabbitai/git-worktree-runner/pull/171))
+- `--to <ref>` for `git gtr clean --merged` to limit cleanup to PRs/MRs merged into a specific target ref, with branch-tip matching for reused branch names ([#167](https://github.com/coderabbitai/git-worktree-runner/pull/167))
+
+### Fixed
+
+- Repo root resolution now works correctly from subdirectories ([#166](https://github.com/coderabbitai/git-worktree-runner/pull/166))
+- Hooks that read stdin no longer drain input and skip later hooks ([#165](https://github.com/coderabbitai/git-worktree-runner/pull/165))
+- Fish `gtr cd` fzf picker now changes directory when pressing Enter ([#172](https://github.com/coderabbitai/git-worktree-runner/pull/172))
+- `git gtr copy` now honors configured `gtr.copy.includeDirs` and `gtr.copy.excludeDirs`, including dry-run, `--all`, and `--from` flows ([#173](https://github.com/coderabbitai/git-worktree-runner/pull/173))
+
 ## [2.6.0] - 2026-03-19
 
 ### Added
@@ -186,7 +200,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Improved base directory resolution logic to distinguish `.` (repo root), `./path` (repo-internal) from other relative values (sibling directories)
 
-[Unreleased]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.5.0...HEAD
+[Unreleased]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.6.0...v2.7.0
+[2.6.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.5.0...v2.6.0
 [2.5.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.4.0...v2.5.0
 [2.4.0]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/coderabbitai/git-worktree-runner/compare/v2.3.0...v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 - Repo root resolution now works correctly from subdirectories ([#166](https://github.com/coderabbitai/git-worktree-runner/pull/166))
 - Hooks that read stdin no longer drain input and skip later hooks ([#165](https://github.com/coderabbitai/git-worktree-runner/pull/165))
-- Fish `gtr cd` fzf picker now changes directory when pressing Enter ([#172](https://github.com/coderabbitai/git-worktree-runner/pull/172))
+- Fish `git gtr cd` fzf picker now changes directory when pressing Enter ([#172](https://github.com/coderabbitai/git-worktree-runner/pull/172))
 - `git gtr copy` now honors configured `gtr.copy.includeDirs` and `gtr.copy.excludeDirs`, including dry-run, `--all`, and `--from` flows ([#173](https://github.com/coderabbitai/git-worktree-runner/pull/173))
 
 ## [2.6.0] - 2026-03-19
@@ -34,9 +34,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- `gtr new --cd` shell integration so newly created worktrees can open in the current shell ([#151](https://github.com/coderabbitai/git-worktree-runner/pull/151))
+- `git gtr new --cd` shell integration so newly created worktrees can open in the current shell ([#151](https://github.com/coderabbitai/git-worktree-runner/pull/151))
 - Cached `git gtr init` output for faster shell startup ([#142](https://github.com/coderabbitai/git-worktree-runner/pull/142))
-- `ctrl-n` keybinding in the interactive `gtr cd` picker to create a new worktree inline ([#141](https://github.com/coderabbitai/git-worktree-runner/pull/141))
+- `ctrl-n` keybinding in the interactive `git gtr cd` picker to create a new worktree inline ([#141](https://github.com/coderabbitai/git-worktree-runner/pull/141))
 
 ### Changed
 
@@ -54,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 
 ### Added
 
-- Interactive fzf worktree picker for `gtr cd` with preview, keybindings, and multi-action support ([#136](https://github.com/coderabbitai/git-worktree-runner/pull/136))
+- Interactive fzf worktree picker for `git gtr cd` with preview, keybindings, and multi-action support ([#136](https://github.com/coderabbitai/git-worktree-runner/pull/136))
 - Helpful error message when running `git gtr cd` explaining shell integration requirement ([#137](https://github.com/coderabbitai/git-worktree-runner/pull/137))
 
 ### Changed
@@ -105,7 +105,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com), and this 
 ### Added
 
 - `mv`/`rename` command for worktree renaming ([#95](https://github.com/coderabbitai/git-worktree-runner/pull/95))
-- Shell integration via `git gtr init` with `gtr cd` navigation ([#104](https://github.com/coderabbitai/git-worktree-runner/pull/104))
+- Shell integration via `git gtr init` with `git gtr cd` navigation ([#104](https://github.com/coderabbitai/git-worktree-runner/pull/104))
 - `postCd` hook for shell integration ([#109](https://github.com/coderabbitai/git-worktree-runner/pull/109))
 - GitLab support for `clean --merged` ([#105](https://github.com/coderabbitai/git-worktree-runner/pull/105))
 - `--folder` flag for custom worktree folder names ([#82](https://github.com/coderabbitai/git-worktree-runner/pull/82))

--- a/bin/git-gtr
+++ b/bin/git-gtr
@@ -11,7 +11,7 @@ if [ -n "${GTR_DEBUG:-}" ]; then
 fi
 
 # Version
-GTR_VERSION="2.6.0"
+GTR_VERSION="2.7.0"
 
 # Find the script directory (resolve symlinks; allow env override)
 resolve_script_dir() {


### PR DESCRIPTION
## Summary
- Bump git gtr version to 2.7.0.
- Add v2.7.0 changelog entries for the merged remote, clean, Fish, copy, hook, and repo-root fixes.
- Update changelog compare links.

## Testing
- `./bin/gtr version`
- `git diff --check`
- `shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh`
- `bats tests/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release**
  * Added 2.7.0 changelog entry dated 2026-04-27 and updated changelog links/labels for consistency.

* **New Features**
  * New remote-selection options for default-branch detection (`--remote` / config)
  * Added `--to <ref>` limit for merged-cleanup flows

* **Bug Fixes**
  * Fixed repo-root detection from subdirectories
  * Fixed stdin-consuming hook behavior
  * Fixed Fish shell navigation for `git gtr cd`
  * Ensured `git gtr copy` respects include/exclude across dry-run and multi-mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->