### PR TITLE
Use registered worktree inventory

### DIFF
--- a/lib/commands/clean.sh
+++ b/lib/commands/clean.sh
@@ -72,6 +72,10 @@ _clean_should_skip() {
 _clean_merged() {
   local repo_root="$1" base_dir="$2" prefix="$3" yes_mode="$4" dry_run="$5" force="${6:-0}" active_worktree_path="${7:-}" target_ref="${8:-}"
 
+  # base_dir and prefix are kept for the helper contract. Merged cleanup uses
+  # Git's registry so nested registered worktrees are processed directly.
+  : "$base_dir" "$prefix"
+
   log_step "Checking for worktrees with merged PRs/MRs..."
 
   local provider
@@ -84,12 +88,14 @@ _clean_merged() {
   local removed=0 skipped=0
   local main_branch
   main_branch=$(current_branch "$repo_root")
+  local records
+  records=$(list_worktree_records "$repo_root")
 
-  for dir in "$base_dir/${prefix}"*; do
-    [ -d "$dir" ] || continue
+  local is_main dir branch _status
+  while IFS=$'\t' read -r is_main dir branch _status; do
+    [ -z "$dir" ] && continue
+    [ "$is_main" = "1" ] && continue
 
-    local branch
-    branch=$(current_branch "$dir") || true
     local branch_tip
     branch_tip=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
 
@@ -134,7 +140,9 @@ _clean_merged() {
         skipped=$((skipped + 1))
       fi
     fi
-  done
+  done <<EOF
+$records
+EOF
 
   echo ""
   if [ "$dry_run" -eq 1 ]; then

--- a/lib/commands/clean.sh
+++ b/lib/commands/clean.sh
@@ -91,57 +91,73 @@ _clean_merged() {
   local records
   records=$(list_worktree_records "$repo_root")
 
-  local is_main dir branch _status
-  while IFS=$'\t' read -r is_main dir branch _status; do
-    [ -z "$dir" ] && continue
-    [ "$is_main" = "1" ] && continue
+  local is_main="" dir="" branch="" line
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        if [ -n "$dir" ] && [ "$is_main" != "1" ]; then
+          local branch_tip
+          branch_tip=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
 
-    local branch_tip
-    branch_tip=$(git -C "$dir" rev-parse HEAD 2>/dev/null || true)
+          # Skip main repo branch silently (not counted)
+          [ "$branch" = "$main_branch" ] && continue
 
-    # Skip main repo branch silently (not counted)
-    [ "$branch" = "$main_branch" ] && continue
+          # Check if branch has a merged PR/MR
+          if check_branch_merged "$provider" "$branch" "$target_ref" "$branch_tip"; then
+            if _clean_should_skip "$dir" "$branch" "$force" "$active_worktree_path"; then
+              skipped=$((skipped + 1))
+              continue
+            fi
 
-    # Check if branch has a merged PR/MR
-    if check_branch_merged "$provider" "$branch" "$target_ref" "$branch_tip"; then
-      if _clean_should_skip "$dir" "$branch" "$force" "$active_worktree_path"; then
-        skipped=$((skipped + 1))
-        continue
-      fi
+            if [ "$dry_run" -eq 1 ]; then
+              log_info "[dry-run] Would remove: $branch ($dir)"
+              removed=$((removed + 1))
+            elif [ "$yes_mode" -eq 1 ] || prompt_yes_no "Remove worktree and delete branch '$branch'?"; then
+              log_step "Removing worktree: $branch"
 
-      if [ "$dry_run" -eq 1 ]; then
-        log_info "[dry-run] Would remove: $branch ($dir)"
-        removed=$((removed + 1))
-      elif [ "$yes_mode" -eq 1 ] || prompt_yes_no "Remove worktree and delete branch '$branch'?"; then
-        log_step "Removing worktree: $branch"
+              if ! run_hooks_in preRemove "$dir" \
+                REPO_ROOT="$repo_root" \
+                WORKTREE_PATH="$dir" \
+                BRANCH="$branch"; then
+                log_warn "Pre-remove hook failed for $branch, skipping"
+                skipped=$((skipped + 1))
+                continue
+              fi
 
-        if ! run_hooks_in preRemove "$dir" \
-          REPO_ROOT="$repo_root" \
-          WORKTREE_PATH="$dir" \
-          BRANCH="$branch"; then
-          log_warn "Pre-remove hook failed for $branch, skipping"
-          skipped=$((skipped + 1))
-          continue
-        fi
+              if remove_worktree "$dir" "$force"; then
+                git branch -d "$branch" 2>/dev/null || git branch -D "$branch" 2>/dev/null || true
+                removed=$((removed + 1))
 
-        if remove_worktree "$dir" "$force"; then
-          git branch -d "$branch" 2>/dev/null || git branch -D "$branch" 2>/dev/null || true
-          removed=$((removed + 1))
-
-          if ! run_hooks postRemove \
-            REPO_ROOT="$repo_root" \
-            WORKTREE_PATH="$dir" \
-            BRANCH="$branch"; then
-            log_warn "Post-remove hook failed for $branch"
+                if ! run_hooks postRemove \
+                  REPO_ROOT="$repo_root" \
+                  WORKTREE_PATH="$dir" \
+                  BRANCH="$branch"; then
+                  log_warn "Post-remove hook failed for $branch"
+                fi
+              fi
+            else
+              log_warn "Skipped: $branch (user declined)"
+              skipped=$((skipped + 1))
+            fi
           fi
         fi
-      else
-        log_warn "Skipped: $branch (user declined)"
-        skipped=$((skipped + 1))
-      fi
-    fi
+        is_main=""
+        dir=""
+        branch=""
+        ;;
+      "is_main "*)
+        is_main="${line#is_main }"
+        ;;
+      "path "*)
+        dir="${line#path }"
+        ;;
+      "branch "*)
+        branch="${line#branch }"
+        ;;
+    esac
   done <<EOF
 $records
+
 EOF
 
   echo ""

--- a/lib/commands/clean.sh
+++ b/lib/commands/clean.sh
@@ -149,10 +149,10 @@ _clean_merged() {
         is_main="${line#is_main }"
         ;;
       "path "*)
-        dir="${line#path }"
+        dir=$(_tsv_unescape_field "${line#path }")
         ;;
       "branch "*)
-        branch="${line#branch }"
+        branch=$(_tsv_unescape_field "${line#branch }")
         ;;
     esac
   done <<EOF

--- a/lib/commands/copy.sh
+++ b/lib/commands/copy.sh
@@ -62,7 +62,7 @@ cmd_copy() {
   # Build target list for --all mode
   if [ "$all_mode" -eq 1 ]; then
     local all_branches
-    all_branches=$(list_worktree_branches "$base_dir" "$prefix")
+    all_branches=$(list_worktree_branches "$base_dir" "$prefix" "$repo_root")
     if [ -z "$all_branches" ]; then
       log_error "No worktrees found"
       exit 1

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -16,17 +16,45 @@ cmd_list() {
   # Machine-readable output (porcelain)
   if [ "$porcelain" -eq 1 ]; then
     # Output: path<tab>branch<tab>status
-    local is_main path branch status linked_rows=""
-    while IFS=$'\t' read -r is_main path branch status; do
-      [ -z "$path" ] && continue
+    local is_main="" path="" branch="" status="" linked_rows="" line
+    while IFS= read -r line; do
+      case "$line" in
+        "")
+          [ -z "$path" ] && continue
+          if [ "$is_main" = "1" ]; then
+            printf "%s\t%s\t%s\n" "$path" "$branch" "$status"
+          else
+            linked_rows="${linked_rows}${path}"$'\t'"${branch}"$'\t'"${status}"$'\n'
+          fi
+          is_main=""
+          path=""
+          branch=""
+          status=""
+          ;;
+        "is_main "*)
+          is_main="${line#is_main }"
+          ;;
+        "path "*)
+          path="${line#path }"
+          ;;
+        "branch "*)
+          branch="${line#branch }"
+          ;;
+        "status "*)
+          status="${line#status }"
+          ;;
+      esac
+    done <<EOF
+$records
+EOF
+
+    if [ -n "$path" ]; then
       if [ "$is_main" = "1" ]; then
         printf "%s\t%s\t%s\n" "$path" "$branch" "$status"
       else
         linked_rows="${linked_rows}${path}"$'\t'"${branch}"$'\t'"${status}"$'\n'
       fi
-    done <<EOF
-$records
-EOF
+    fi
 
     if [ -n "$linked_rows" ]; then
       printf "%s" "$linked_rows" | LC_ALL=C sort -t "$(printf '\t')" -k2,2 -k1,1
@@ -40,17 +68,45 @@ EOF
   printf "%-30s %s\n" "BRANCH" "PATH"
   printf "%-30s %s\n" "------" "----"
 
-  local is_main path branch status linked_rows=""
-  while IFS=$'\t' read -r is_main path branch status; do
-    [ -z "$path" ] && continue
+  local is_main="" path="" branch="" status="" linked_rows="" line
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        [ -z "$path" ] && continue
+        if [ "$is_main" = "1" ]; then
+          printf "%-30s %s\n" "$branch [main repo]" "$path"
+        else
+          linked_rows="${linked_rows}${branch}"$'\t'"${path}"$'\n'
+        fi
+        is_main=""
+        path=""
+        branch=""
+        status=""
+        ;;
+      "is_main "*)
+        is_main="${line#is_main }"
+        ;;
+      "path "*)
+        path="${line#path }"
+        ;;
+      "branch "*)
+        branch="${line#branch }"
+        ;;
+      "status "*)
+        status="${line#status }"
+        ;;
+    esac
+  done <<EOF
+$records
+EOF
+
+  if [ -n "$path" ]; then
     if [ "$is_main" = "1" ]; then
       printf "%-30s %s\n" "$branch [main repo]" "$path"
     else
       linked_rows="${linked_rows}${branch}"$'\t'"${path}"$'\n'
     fi
-  done <<EOF
-$records
-EOF
+  fi
 
   if [ -n "$linked_rows" ]; then
     printf "%s" "$linked_rows" | LC_ALL=C sort -t "$(printf '\t')" -k1,1 -k2,2 | while IFS=$'\t' read -r branch path; do

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -9,28 +9,27 @@ cmd_list() {
 
   resolve_repo_context || exit 1
 
-  local repo_root="$_ctx_repo_root" base_dir="$_ctx_base_dir" prefix="$_ctx_prefix"
+  local repo_root="$_ctx_repo_root"
+  local records
+  records=$(list_worktree_records "$repo_root")
 
   # Machine-readable output (porcelain)
   if [ "$porcelain" -eq 1 ]; then
     # Output: path<tab>branch<tab>status
-    local branch status
-    branch=$(current_branch "$repo_root")
-    status=$(worktree_status "$repo_root")
-    printf "%s\t%s\t%s\n" "$repo_root" "$branch" "$status"
+    local is_main path branch status linked_rows=""
+    while IFS=$'\t' read -r is_main path branch status; do
+      [ -z "$path" ] && continue
+      if [ "$is_main" = "1" ]; then
+        printf "%s\t%s\t%s\n" "$path" "$branch" "$status"
+      else
+        linked_rows="${linked_rows}${path}"$'\t'"${branch}"$'\t'"${status}"$'\n'
+      fi
+    done <<EOF
+$records
+EOF
 
-    if [ -d "$base_dir" ]; then
-      # Find all worktree directories and output: path<tab>branch<tab>status
-      # Exclude the base directory itself to avoid matching when prefix is empty
-      find "$base_dir" -maxdepth 1 -type d -name "${prefix}*" 2>/dev/null | while IFS= read -r dir; do
-        # Skip the base directory itself
-        [ "$dir" = "$base_dir" ] && continue
-        local branch status
-        branch=$(current_branch "$dir")
-        [ -z "$branch" ] && branch="(detached)"
-        status=$(worktree_status "$dir")
-        printf "%s\t%s\t%s\n" "$dir" "$branch" "$status"
-      done | LC_ALL=C sort -k2,2
+    if [ -n "$linked_rows" ]; then
+      printf "%s" "$linked_rows" | LC_ALL=C sort -t "$(printf '\t')" -k2,2 -k1,1
     fi
     return 0
   fi
@@ -41,21 +40,23 @@ cmd_list() {
   printf "%-30s %s\n" "BRANCH" "PATH"
   printf "%-30s %s\n" "------" "----"
 
-  # Always show repo root first
-  local branch
-  branch=$(current_branch "$repo_root")
-  printf "%-30s %s\n" "$branch [main repo]" "$repo_root"
+  local is_main path branch status linked_rows=""
+  while IFS=$'\t' read -r is_main path branch status; do
+    [ -z "$path" ] && continue
+    if [ "$is_main" = "1" ]; then
+      printf "%-30s %s\n" "$branch [main repo]" "$path"
+    else
+      linked_rows="${linked_rows}${branch}"$'\t'"${path}"$'\n'
+    fi
+  done <<EOF
+$records
+EOF
 
-  # Show worktrees sorted by branch name
-  if [ -d "$base_dir" ]; then
-    find "$base_dir" -maxdepth 1 -type d -name "${prefix}*" 2>/dev/null | while IFS= read -r dir; do
-      # Skip the base directory itself
-      [ "$dir" = "$base_dir" ] && continue
-      local branch
-      branch=$(current_branch "$dir")
-      [ -z "$branch" ] && branch="(detached)"
-      printf "%-30s %s\n" "$branch" "$dir"
-    done | LC_ALL=C sort -k1,1
+  if [ -n "$linked_rows" ]; then
+    printf "%s" "$linked_rows" | LC_ALL=C sort -t "$(printf '\t')" -k1,1 -k2,2 | while IFS=$'\t' read -r branch path; do
+      [ -z "$path" ] && continue
+      printf "%-30s %s\n" "$branch" "$path"
+    done
   fi
 
   echo ""

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -35,10 +35,10 @@ cmd_list() {
           is_main="${line#is_main }"
           ;;
         "path "*)
-          path="${line#path }"
+          path=$(_tsv_unescape_field "${line#path }")
           ;;
         "branch "*)
-          branch="${line#branch }"
+          branch=$(_tsv_unescape_field "${line#branch }")
           ;;
         "status "*)
           status="${line#status }"
@@ -87,10 +87,10 @@ EOF
         is_main="${line#is_main }"
         ;;
       "path "*)
-        path="${line#path }"
+        path=$(_tsv_unescape_field "${line#path }")
         ;;
       "branch "*)
-        branch="${line#branch }"
+        branch=$(_tsv_unescape_field "${line#branch }")
         ;;
       "status "*)
         status="${line#status }"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -219,12 +219,15 @@ _emit_worktree_record() {
   [ -z "$branch" ] && branch="(detached)"
   status=$(_worktree_record_status "$wt_detached" "$wt_locked" "$wt_prunable")
 
-  printf "%s\t%s\t%s\t%s\n" "$is_main" "$wt_path" "$branch" "$status"
+  printf "is_main %s\n" "$is_main"
+  printf "path %s\n" "$wt_path"
+  printf "branch %s\n" "$branch"
+  printf "status %s\n\n" "$status"
 }
 
 # List registered git worktrees for a repository.
 # Usage: list_worktree_records repo_root
-# Output: is_main<TAB>path<TAB>branch<TAB>status
+# Output: blank-line-delimited records with is_main/path/branch/status fields
 list_worktree_records() {
   local repo_root="$1"
   local repo_root_canonical
@@ -293,16 +296,46 @@ worktree_status() {
   local repo_root
   repo_root=$(_resolve_main_repo_root) || return 1
 
-  local is_main path branch record_status
-  while IFS=$'\t' read -r is_main path branch record_status; do
-    if [ "$path" = "$target_path" ] || [ "$path" = "$target_path_canonical" ]; then
-      found=1
-      status="$record_status"
-      break
-    fi
+  local is_main="" path="" branch="" record_status="" line path_canonical
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        [ -z "$path" ] && continue
+        path_canonical=$(canonicalize_path "$path" || printf "%s" "$path")
+        if [ "$path" = "$target_path" ] || [ "$path_canonical" = "$target_path_canonical" ]; then
+          found=1
+          status="$record_status"
+          break
+        fi
+        is_main=""
+        path=""
+        branch=""
+        record_status=""
+        ;;
+      "is_main "*)
+        is_main="${line#is_main }"
+        ;;
+      "path "*)
+        path="${line#path }"
+        ;;
+      "branch "*)
+        branch="${line#branch }"
+        ;;
+      "status "*)
+        record_status="${line#status }"
+        ;;
+    esac
   done <<EOF
 $(list_worktree_records "$repo_root")
 EOF
+
+  if [ "$found" -eq 0 ] && [ -n "$path" ]; then
+    path_canonical=$(canonicalize_path "$path" || printf "%s" "$path")
+    if [ "$path" = "$target_path" ] || [ "$path_canonical" = "$target_path_canonical" ]; then
+      found=1
+      status="$record_status"
+    fi
+  fi
 
   # If worktree not found in git's list
   if [ "$found" -eq 0 ]; then
@@ -361,15 +394,36 @@ resolve_target() {
   fi
 
   # Last resort: ask git for all worktrees (catches non-gtr-managed worktrees)
-  local is_main wt_path wt_branch _wt_status
-  while IFS=$'\t' read -r is_main wt_path wt_branch _wt_status; do
-    if [ "$wt_branch" = "$identifier" ]; then
-      printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
-      return 0
-    fi
+  local is_main="" wt_path="" wt_branch="" line
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        if [ "$wt_branch" = "$identifier" ]; then
+          printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
+          return 0
+        fi
+        is_main=""
+        wt_path=""
+        wt_branch=""
+        ;;
+      "is_main "*)
+        is_main="${line#is_main }"
+        ;;
+      "path "*)
+        wt_path="${line#path }"
+        ;;
+      "branch "*)
+        wt_branch="${line#branch }"
+        ;;
+    esac
   done <<EOF
 $(list_worktree_records "$repo_root")
 EOF
+
+  if [ "$wt_branch" = "$identifier" ]; then
+    printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
+    return 0
+  fi
 
   log_error "Worktree not found for branch: $identifier"
   return 1
@@ -622,13 +676,32 @@ list_worktree_branches() {
   local records
   records=$(list_worktree_records "$repo_root")
 
-  local is_main path branch status
-  while IFS=$'\t' read -r is_main path branch status; do
-    [ "$is_main" = "1" ] && continue
-    [ -z "$branch" ] && continue
-    [ "$branch" = "(detached)" ] && continue
-    printf "%s\n" "$branch"
+  local is_main="" path="" branch="" line
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        if [ "$is_main" != "1" ] && [ -n "$branch" ] && [ "$branch" != "(detached)" ]; then
+          printf "%s\n" "$branch"
+        fi
+        is_main=""
+        path=""
+        branch=""
+        ;;
+      "is_main "*)
+        is_main="${line#is_main }"
+        ;;
+      "path "*)
+        path="${line#path }"
+        ;;
+      "branch "*)
+        branch="${line#branch }"
+        ;;
+    esac
   done <<EOF
 $records
 EOF
+
+  if [ "$is_main" != "1" ] && [ -n "$branch" ] && [ "$branch" != "(detached)" ]; then
+    printf "%s\n" "$branch"
+  fi
 }

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -214,8 +214,11 @@ _emit_worktree_record() {
 
   [ -z "$wt_path" ] && return 0
 
-  local is_main=0 branch="$wt_branch" status
-  [ "$wt_path" = "$repo_root" ] && is_main=1
+  local is_main=0 branch="$wt_branch" status wt_path_canonical
+  wt_path_canonical=$(canonicalize_path "$wt_path" || printf "%s" "$wt_path")
+  if [ "$wt_path" = "$repo_root" ] || [ "$wt_path_canonical" = "$repo_root" ]; then
+    is_main=1
+  fi
   [ -z "$branch" ] && branch="(detached)"
   status=$(_worktree_record_status "$wt_detached" "$wt_locked" "$wt_prunable")
 
@@ -660,13 +663,15 @@ resolve_repo_context() {
 }
 
 # List all worktree branch names (excluding main repo)
-# Usage: list_worktree_branches base_dir prefix
+# Usage: list_worktree_branches base_dir prefix [repo_root]
 # Returns: newline-separated list of branch names
 list_worktree_branches() {
   local base_dir="$1"
   local prefix="$2"
-  local repo_root
-  repo_root=$(_resolve_main_repo_root) || return 0
+  local repo_root="${3:-}"
+  if [ -z "$repo_root" ]; then
+    repo_root=$(_resolve_main_repo_root) || return 0
+  fi
 
   # base_dir and prefix are kept for the public helper contract. Worktree
   # discovery itself comes from Git's registry so nested registered worktrees

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -223,28 +223,19 @@ _emit_worktree_record() {
   status=$(_worktree_record_status "$wt_detached" "$wt_locked" "$wt_prunable")
 
   printf "is_main %s\n" "$is_main"
-  printf "path %s\n" "$wt_path"
-  printf "branch %s\n" "$branch"
+  printf "path %s\n" "$(_tsv_escape_field "$wt_path")"
+  printf "branch %s\n" "$(_tsv_escape_field "$branch")"
   printf "status %s\n\n" "$status"
 }
 
-# List registered git worktrees for a repository.
-# Usage: list_worktree_records repo_root
-# Output: blank-line-delimited records with is_main/path/branch/status fields
-list_worktree_records() {
-  local repo_root="$1"
-  local repo_root_canonical
-  repo_root_canonical=$(canonicalize_path "$repo_root" || printf "%s" "$repo_root")
-
-  local porcelain_output
-
-  porcelain_output=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null) || return 0
-
+_parse_worktree_records() {
+  local repo_root_canonical="$1"
+  local delimiter="$2"
   local wt_path="" wt_branch="" wt_detached=0 wt_locked=0 wt_prunable=0
+  local field
 
-  local line
-  while IFS= read -r line; do
-    case "$line" in
+  while IFS= read -r -d "$delimiter" field; do
+    case "$field" in
       "")
         _emit_worktree_record "$repo_root_canonical" "$wt_path" "$wt_branch" "$wt_detached" "$wt_locked" "$wt_prunable"
         wt_path=""
@@ -261,13 +252,13 @@ list_worktree_records() {
           wt_locked=0
           wt_prunable=0
         fi
-        wt_path="${line#worktree }"
+        wt_path="${field#worktree }"
         ;;
       "branch refs/heads/"*)
-        wt_branch="${line#branch refs/heads/}"
+        wt_branch="${field#branch refs/heads/}"
         ;;
       "branch "*)
-        wt_branch="${line#branch }"
+        wt_branch="${field#branch }"
         ;;
       detached)
         wt_detached=1
@@ -279,11 +270,24 @@ list_worktree_records() {
         wt_prunable=1
         ;;
     esac
-  done <<EOF
-$porcelain_output
-EOF
+  done
 
   _emit_worktree_record "$repo_root_canonical" "$wt_path" "$wt_branch" "$wt_detached" "$wt_locked" "$wt_prunable"
+}
+
+# List registered git worktrees for a repository.
+# Usage: list_worktree_records repo_root
+# Output: blank-line-delimited records with is_main/path/branch/status fields
+list_worktree_records() {
+  local repo_root="$1"
+  local repo_root_canonical
+  repo_root_canonical=$(canonicalize_path "$repo_root" || printf "%s" "$repo_root")
+
+  if git -C "$repo_root" worktree list --porcelain -z >/dev/null 2>&1; then
+    _parse_worktree_records "$repo_root_canonical" "" < <(git -C "$repo_root" worktree list --porcelain -z 2>/dev/null)
+  else
+    _parse_worktree_records "$repo_root_canonical" $'\n' < <(git -C "$repo_root" worktree list --porcelain 2>/dev/null)
+  fi
 }
 
 # Get the status of a worktree from git
@@ -319,10 +323,10 @@ worktree_status() {
         is_main="${line#is_main }"
         ;;
       "path "*)
-        path="${line#path }"
+        path=$(_tsv_unescape_field "${line#path }")
         ;;
       "branch "*)
-        branch="${line#branch }"
+        branch=$(_tsv_unescape_field "${line#branch }")
         ;;
       "status "*)
         record_status="${line#status }"
@@ -463,10 +467,10 @@ resolve_target() {
         is_main="${line#is_main }"
         ;;
       "path "*)
-        wt_path="${line#path }"
+        wt_path=$(_tsv_unescape_field "${line#path }")
         ;;
       "branch "*)
-        wt_branch="${line#branch }"
+        wt_branch=$(_tsv_unescape_field "${line#branch }")
         ;;
     esac
   done <<EOF
@@ -748,10 +752,10 @@ list_worktree_branches() {
         is_main="${line#is_main }"
         ;;
       "path "*)
-        path="${line#path }"
+        path=$(_tsv_unescape_field "${line#path }")
         ;;
       "branch "*)
-        branch="${line#branch }"
+        branch=$(_tsv_unescape_field "${line#branch }")
         ;;
     esac
   done <<EOF

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -190,49 +190,118 @@ current_branch() {
   printf "%s" "$branch"
 }
 
+_worktree_record_status() {
+  local detached="$1" locked="$2" prunable="$3"
+
+  if [ "$locked" -eq 1 ]; then
+    printf "locked"
+  elif [ "$prunable" -eq 1 ]; then
+    printf "prunable"
+  elif [ "$detached" -eq 1 ]; then
+    printf "detached"
+  else
+    printf "ok"
+  fi
+}
+
+_emit_worktree_record() {
+  local repo_root="$1"
+  local wt_path="$2"
+  local wt_branch="$3"
+  local wt_detached="$4"
+  local wt_locked="$5"
+  local wt_prunable="$6"
+
+  [ -z "$wt_path" ] && return 0
+
+  local is_main=0 branch="$wt_branch" status
+  [ "$wt_path" = "$repo_root" ] && is_main=1
+  [ -z "$branch" ] && branch="(detached)"
+  status=$(_worktree_record_status "$wt_detached" "$wt_locked" "$wt_prunable")
+
+  printf "%s\t%s\t%s\t%s\n" "$is_main" "$wt_path" "$branch" "$status"
+}
+
+# List registered git worktrees for a repository.
+# Usage: list_worktree_records repo_root
+# Output: is_main<TAB>path<TAB>branch<TAB>status
+list_worktree_records() {
+  local repo_root="$1"
+  local repo_root_canonical
+  repo_root_canonical=$(canonicalize_path "$repo_root" || printf "%s" "$repo_root")
+
+  local porcelain_output
+
+  porcelain_output=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null) || return 0
+
+  local wt_path="" wt_branch="" wt_detached=0 wt_locked=0 wt_prunable=0
+
+  local line
+  while IFS= read -r line; do
+    case "$line" in
+      "")
+        _emit_worktree_record "$repo_root_canonical" "$wt_path" "$wt_branch" "$wt_detached" "$wt_locked" "$wt_prunable"
+        wt_path=""
+        wt_branch=""
+        wt_detached=0
+        wt_locked=0
+        wt_prunable=0
+        ;;
+      "worktree "*)
+        if [ -n "$wt_path" ]; then
+          _emit_worktree_record "$repo_root_canonical" "$wt_path" "$wt_branch" "$wt_detached" "$wt_locked" "$wt_prunable"
+          wt_branch=""
+          wt_detached=0
+          wt_locked=0
+          wt_prunable=0
+        fi
+        wt_path="${line#worktree }"
+        ;;
+      "branch refs/heads/"*)
+        wt_branch="${line#branch refs/heads/}"
+        ;;
+      "branch "*)
+        wt_branch="${line#branch }"
+        ;;
+      detached)
+        wt_detached=1
+        ;;
+      locked*)
+        wt_locked=1
+        ;;
+      prunable*)
+        wt_prunable=1
+        ;;
+    esac
+  done <<EOF
+$porcelain_output
+EOF
+
+  _emit_worktree_record "$repo_root_canonical" "$wt_path" "$wt_branch" "$wt_detached" "$wt_locked" "$wt_prunable"
+}
+
 # Get the status of a worktree from git
 # Usage: worktree_status worktree_path
 # Returns: status (ok, detached, locked, prunable, or missing)
 worktree_status() {
   local target_path="$1"
-  local porcelain_output
-  local in_section=0
+  local target_path_canonical
+  target_path_canonical=$(canonicalize_path "$target_path" || printf "%s" "$target_path")
+
   local status="ok"
   local found=0
+  local repo_root
+  repo_root=$(_resolve_main_repo_root) || return 1
 
-  # Parse git worktree list --porcelain line by line
-  porcelain_output=$(git worktree list --porcelain 2>/dev/null)
-
-  while IFS= read -r line; do
-    # Check if this is the start of our target worktree
-    if [ "$line" = "worktree $target_path" ]; then
-      in_section=1
+  local is_main path branch record_status
+  while IFS=$'\t' read -r is_main path branch record_status; do
+    if [ "$path" = "$target_path" ] || [ "$path" = "$target_path_canonical" ]; then
       found=1
-      continue
-    fi
-
-    # If we're in the target section, check for status lines
-    if [ "$in_section" -eq 1 ]; then
-      # Empty line marks end of section
-      if [ -z "$line" ]; then
-        break
-      fi
-
-      # Check for status indicators (priority: locked > prunable > detached)
-      case "$line" in
-        locked*)
-          status="locked"
-          ;;
-        prunable*)
-          [ "$status" = "ok" ] && status="prunable"
-          ;;
-        detached)
-          [ "$status" = "ok" ] && status="detached"
-          ;;
-      esac
+      status="$record_status"
+      break
     fi
   done <<EOF
-$porcelain_output
+$(list_worktree_records "$repo_root")
 EOF
 
   # If worktree not found in git's list
@@ -292,22 +361,15 @@ resolve_target() {
   fi
 
   # Last resort: ask git for all worktrees (catches non-gtr-managed worktrees)
-  local wt_path wt_branch
-  while IFS= read -r line; do
-    case "$line" in
-      "worktree "*)  wt_path="${line#worktree }" ;;
-      "branch "*)
-        wt_branch="${line#branch refs/heads/}"
-        if [ "$wt_branch" = "$identifier" ]; then
-          local is_main=0
-          [ "$wt_path" = "$repo_root" ] && is_main=1
-          printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
-          return 0
-        fi
-        ;;
-      "")  wt_path="" ; wt_branch="" ;;
-    esac
-  done < <(git -C "$repo_root" worktree list --porcelain 2>/dev/null)
+  local is_main wt_path wt_branch _wt_status
+  while IFS=$'\t' read -r is_main wt_path wt_branch _wt_status; do
+    if [ "$wt_branch" = "$identifier" ]; then
+      printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
+      return 0
+    fi
+  done <<EOF
+$(list_worktree_records "$repo_root")
+EOF
 
   log_error "Worktree not found for branch: $identifier"
   return 1
@@ -549,13 +611,24 @@ resolve_repo_context() {
 list_worktree_branches() {
   local base_dir="$1"
   local prefix="$2"
+  local repo_root
+  repo_root=$(_resolve_main_repo_root) || return 0
 
-  [ ! -d "$base_dir" ] && return 0
+  # base_dir and prefix are kept for the public helper contract. Worktree
+  # discovery itself comes from Git's registry so nested registered worktrees
+  # are included and arbitrary parent directories are ignored.
+  : "$base_dir" "$prefix"
 
-  for dir in "$base_dir/${prefix}"*; do
-    [ -d "$dir" ] || continue
-    local branch
-    branch=$(current_branch "$dir")
-    [ -n "$branch" ] && echo "$branch"
-  done
+  local records
+  records=$(list_worktree_records "$repo_root")
+
+  local is_main path branch status
+  while IFS=$'\t' read -r is_main path branch status; do
+    [ "$is_main" = "1" ] && continue
+    [ -z "$branch" ] && continue
+    [ "$branch" = "(detached)" ] && continue
+    printf "%s\n" "$branch"
+  done <<EOF
+$records
+EOF
 }

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -351,8 +351,8 @@ EOF
 _tsv_escape_field() {
   local value="$1"
   value=${value//\\/\\\\}
-  value=${value//$'\t'/\\\\t}
-  value=${value//$'\n'/\\\\n}
+  value=${value//$'\t'/$'\\t'}
+  value=${value//$'\n'/$'\\n'}
   printf "%s" "$value"
 }
 
@@ -488,8 +488,7 @@ EOF
 unpack_target() {
   local escaped_path escaped_branch
   local IFS=$'\t'
-  # shellcheck disable=SC2162
-  read _ctx_is_main escaped_path escaped_branch <<< "$1"
+  read -r _ctx_is_main escaped_path escaped_branch <<< "$1"
   _ctx_worktree_path=$(_tsv_unescape_field "$escaped_path")
   _ctx_branch=$(_tsv_unescape_field "$escaped_branch")
 }

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -348,9 +348,59 @@ EOF
   printf "%s" "$status"
 }
 
+_tsv_escape_field() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//$'\t'/\\\\t}
+  value=${value//$'\n'/\\\\n}
+  printf "%s" "$value"
+}
+
+_tsv_unescape_field() {
+  local value="$1" out="" char next
+
+  while [ -n "$value" ]; do
+    char="${value:0:1}"
+    value="${value:1}"
+
+    if [ "$char" = "\\" ]; then
+      if [ -z "$value" ]; then
+        out="${out}\\"
+        break
+      fi
+
+      next="${value:0:1}"
+      value="${value:1}"
+      case "$next" in
+        t)
+          out="${out}"$'\t'
+          ;;
+        n)
+          out="${out}"$'\n'
+          ;;
+        "\\")
+          out="${out}\\"
+          ;;
+        *)
+          out="${out}\\${next}"
+          ;;
+      esac
+    else
+      out="${out}${char}"
+    fi
+  done
+
+  printf "%s" "$out"
+}
+
+_print_resolved_target() {
+  local is_main="$1" path="$2" branch="$3"
+  printf "%s\t%s\t%s\n" "$is_main" "$(_tsv_escape_field "$path")" "$(_tsv_escape_field "$branch")"
+}
+
 # Resolve a worktree target from branch name or special ID '1' for main repo
 # Usage: resolve_target identifier repo_root base_dir prefix
-# Returns: tab-separated "is_main\tpath\tbranch" on success (is_main: 1 for main repo, 0 for worktrees)
+# Returns: tab-separated "is_main\tpath\tbranch" with escaped fields on success (is_main: 1 for main repo, 0 for worktrees)
 # Exit code: 0 on success, 1 if not found
 resolve_target() {
   local identifier="$1"
@@ -363,7 +413,7 @@ resolve_target() {
   if [ "$identifier" = "1" ]; then
     path="$repo_root"
     branch=$(get_current_branch "$repo_root")
-    printf "1\t%s\t%s\n" "$path" "$branch"
+    _print_resolved_target "1" "$path" "$branch"
     return 0
   fi
 
@@ -371,7 +421,7 @@ resolve_target() {
   # First check if it's the current branch in repo root (if not ID 1)
   branch=$(get_current_branch "$repo_root")
   if [ "$branch" = "$identifier" ]; then
-    printf "1\t%s\t%s\n" "$repo_root" "$identifier"
+    _print_resolved_target "1" "$repo_root" "$identifier"
     return 0
   fi
 
@@ -380,7 +430,7 @@ resolve_target() {
   path="$base_dir/${prefix}${sanitized_name}"
   if [ -d "$path" ]; then
     branch=$(current_branch "$path")
-    printf "0\t%s\t%s\n" "$path" "$branch"
+    _print_resolved_target "0" "$path" "$branch"
     return 0
   fi
 
@@ -390,7 +440,7 @@ resolve_target() {
       [ -d "$dir" ] || continue
       branch=$(current_branch "$dir")
       if [ "$branch" = "$identifier" ]; then
-        printf "0\t%s\t%s\n" "$dir" "$branch"
+        _print_resolved_target "0" "$dir" "$branch"
         return 0
       fi
     done
@@ -402,7 +452,7 @@ resolve_target() {
     case "$line" in
       "")
         if [ "$wt_branch" = "$identifier" ]; then
-          printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
+          _print_resolved_target "$is_main" "$wt_path" "$wt_branch"
           return 0
         fi
         is_main=""
@@ -424,7 +474,7 @@ $(list_worktree_records "$repo_root")
 EOF
 
   if [ "$wt_branch" = "$identifier" ]; then
-    printf "%s\t%s\t%s\n" "$is_main" "$wt_path" "$wt_branch"
+    _print_resolved_target "$is_main" "$wt_path" "$wt_branch"
     return 0
   fi
 
@@ -436,9 +486,12 @@ EOF
 # Sets: _ctx_is_main, _ctx_worktree_path, _ctx_branch
 # Usage: unpack_target "$target_string"
 unpack_target() {
+  local escaped_path escaped_branch
   local IFS=$'\t'
   # shellcheck disable=SC2162
-  read _ctx_is_main _ctx_worktree_path _ctx_branch <<< "$1"
+  read _ctx_is_main escaped_path escaped_branch <<< "$1"
+  _ctx_worktree_path=$(_tsv_unescape_field "$escaped_path")
+  _ctx_branch=$(_tsv_unescape_field "$escaped_branch")
 }
 
 # Resolve an identifier to a worktree and set _ctx_* variables in one step

--- a/tests/cmd_clean.bats
+++ b/tests/cmd_clean.bats
@@ -145,6 +145,28 @@ teardown() {
   [ ! -d "$TEST_WORKTREES_DIR/merged-force" ]
 }
 
+@test "cmd_clean --merged uses nested registered worktree path" {
+  mkdir -p "$TEST_WORKTREES_DIR/jsmith"
+  git -C "$TEST_REPO" worktree add "$TEST_WORKTREES_DIR/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  _clean_detect_provider() { printf "github"; }
+  ensure_provider_cli() { return 0; }
+  check_branch_merged() {
+    [ "$2" = "jsmith/my-feature" ]
+  }
+  run_hooks_in() {
+    printf "preRemove:%s\n" "$2"
+    return 0
+  }
+  run_hooks() { return 0; }
+
+  run cmd_clean --merged --force --yes
+  [ "$status" -eq 0 ]
+  [ ! -d "$TEST_WORKTREES_DIR/jsmith/my-feature" ]
+  [[ "$output" == *"preRemove:$TEST_WORKTREES_DIR/jsmith/my-feature"* ]]
+  [ ! -e "$TEST_WORKTREES_DIR/jsmith/.git" ]
+}
+
 @test "cmd_clean --merged --to filters by target ref" {
   create_test_worktree "merged-to-main"
   create_test_worktree "merged-to-feature"

--- a/tests/cmd_copy.bats
+++ b/tests/cmd_copy.bats
@@ -80,6 +80,17 @@ teardown() {
   [ -f "$TEST_WORKTREES_DIR/copy-target-2/.env" ]
 }
 
+@test "cmd_copy --all copies to nested registered worktree only" {
+  mkdir -p "$TEST_WORKTREES_DIR/jsmith"
+  git -C "$TEST_REPO" worktree add "$TEST_WORKTREES_DIR/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  run cmd_copy --all -- ".env"
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_WORKTREES_DIR/copy-target/.env" ]
+  [ -f "$TEST_WORKTREES_DIR/jsmith/my-feature/.env" ]
+  [ ! -e "$TEST_WORKTREES_DIR/jsmith/.env" ]
+}
+
 @test "cmd_copy --all copies configured includeDirs to all worktrees" {
   create_test_worktree "copy-target-2"
   mkdir -p "$TEST_REPO/.zed"

--- a/tests/cmd_list.bats
+++ b/tests/cmd_list.bats
@@ -25,6 +25,17 @@ teardown() {
   [[ "$output" == *"list-me"* ]]
 }
 
+@test "cmd_list shows nested externally-created worktree" {
+  mkdir -p "$TEST_WORKTREES_DIR/jsmith"
+  git -C "$TEST_REPO" worktree add "$TEST_WORKTREES_DIR/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  run cmd_list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"jsmith/my-feature"* ]]
+  [[ "$output" == *"$TEST_WORKTREES_DIR/jsmith/my-feature"* ]]
+  [[ "$output" != *"(detached)"*"$TEST_WORKTREES_DIR/jsmith"* ]]
+}
+
 @test "cmd_list --porcelain outputs TSV format" {
   create_test_worktree "porcelain-test"
   local output
@@ -43,6 +54,19 @@ teardown() {
   output=$(cmd_list --porcelain)
   # Worktree line should have: path<tab>branch<tab>status
   [[ "$output" == *"tsv-test"*$'\t'*"ok"* ]]
+}
+
+@test "cmd_list --porcelain includes nested externally-created worktree" {
+  mkdir -p "$TEST_WORKTREES_DIR/jsmith"
+  git -C "$TEST_REPO" worktree add "$TEST_WORKTREES_DIR/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  local output
+  output=$(cmd_list --porcelain)
+
+  local expected_row="$TEST_WORKTREES_DIR/jsmith/my-feature"$'\t'"jsmith/my-feature"$'\t'"ok"
+  local bogus_parent="$TEST_WORKTREES_DIR/jsmith"$'\t'"(detached)"$'\t'"missing"
+  [[ "$output" == *"$expected_row"* ]]
+  [[ "$output" != *"$bogus_parent"* ]]
 }
 
 @test "cmd_list with no worktrees still works" {

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -115,11 +115,15 @@ teardown() {
   records=$(list_worktree_records "$TEST_REPO")
   local repo_root
   repo_root=$(cd "$TEST_REPO" && pwd -P)
+  local normal_path detached_path locked_path
+  normal_path=$(cd "$TEST_WORKTREES_DIR/records-normal" && pwd -P)
+  detached_path=$(cd "$TEST_WORKTREES_DIR/records-detached" && pwd -P)
+  locked_path=$(cd "$TEST_WORKTREES_DIR/records-locked" && pwd -P)
 
-  [[ "$records" == *"1"$'\t'"$repo_root"$'\t'*$'\t'"ok"* ]]
-  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-normal"$'\t'"records-normal"$'\t'"ok"* ]]
-  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-detached"$'\t'"(detached)"$'\t'"detached"* ]]
-  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-locked"$'\t'"records-locked"$'\t'"locked"* ]]
+  [[ "$records" == *"is_main 1"$'\n'"path $repo_root"$'\n'*"status ok"* ]]
+  [[ "$records" == *"is_main 0"$'\n'"path $normal_path"$'\n'"branch records-normal"$'\n'"status ok"* ]]
+  [[ "$records" == *"is_main 0"$'\n'"path $detached_path"$'\n'"branch (detached)"$'\n'"status detached"* ]]
+  [[ "$records" == *"is_main 0"$'\n'"path $locked_path"$'\n'"branch records-locked"$'\n'"status locked"* ]]
 
   git -C "$TEST_REPO" worktree unlock "$TEST_WORKTREES_DIR/records-locked"
 }

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -68,6 +68,14 @@ teardown() {
   [ "$_ctx_branch" = "main" ]
 }
 
+@test "resolved target escaping round-trips tabs newlines and backslashes" {
+  local value="/tmp/path"$'\t'"with"$'\n'"chars\\tail"
+  local escaped
+  escaped=$(_tsv_escape_field "$value")
+
+  [ "$(_tsv_unescape_field "$escaped")" = "$value" ]
+}
+
 @test "resolve_worktree sets context globals" {
   create_test_worktree "ctx-test"
   resolve_worktree "ctx-test" "$TEST_REPO" "$TEST_WORKTREES_DIR" ""

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -76,6 +76,19 @@ teardown() {
   [ "$_ctx_branch" = "ctx-test" ]
 }
 
+@test "resolve_worktree preserves tab in externally registered worktree path" {
+  local tab_path="${TEST_REPO}-external"$'\t'"tab"
+  git -C "$TEST_REPO" worktree add "$tab_path" -b resolve-tab-path --quiet
+  local expected_path
+  expected_path=$(cd "$tab_path" && pwd -P)
+
+  resolve_worktree "resolve-tab-path" "$TEST_REPO" "$TEST_WORKTREES_DIR" ""
+
+  [ "$_ctx_is_main" = "0" ]
+  [ "$_ctx_worktree_path" = "$expected_path" ]
+  [ "$_ctx_branch" = "resolve-tab-path" ]
+}
+
 @test "resolve_worktree returns 1 for unknown branch" {
   run resolve_worktree "nope" "$TEST_REPO" "$TEST_WORKTREES_DIR" ""
   [ "$status" -eq 1 ]

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -93,6 +93,37 @@ teardown() {
   [[ "$result" == "0"$'\t'*"-external"$'\t'"external-branch" ]]
 }
 
+@test "resolve_target finds nested externally-created worktree under base dir" {
+  mkdir -p "$TEST_WORKTREES_DIR/jsmith"
+  git -C "$TEST_REPO" worktree add "$TEST_WORKTREES_DIR/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  local result
+  result=$(resolve_target "jsmith/my-feature" "$TEST_REPO" "$TEST_WORKTREES_DIR" "")
+  local expected_path
+  expected_path=$(cd "$TEST_WORKTREES_DIR/jsmith/my-feature" && pwd -P)
+
+  [[ "$result" == "0"$'\t'"$expected_path"$'\t'"jsmith/my-feature" ]]
+}
+
+@test "list_worktree_records reports normal detached and locked worktrees" {
+  create_test_worktree "records-normal"
+  git -C "$TEST_REPO" worktree add --detach "$TEST_WORKTREES_DIR/records-detached" HEAD --quiet
+  create_test_worktree "records-locked"
+  git -C "$TEST_REPO" worktree lock "$TEST_WORKTREES_DIR/records-locked" --reason "test lock"
+
+  local records
+  records=$(list_worktree_records "$TEST_REPO")
+  local repo_root
+  repo_root=$(cd "$TEST_REPO" && pwd -P)
+
+  [[ "$records" == *"1"$'\t'"$repo_root"$'\t'*$'\t'"ok"* ]]
+  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-normal"$'\t'"records-normal"$'\t'"ok"* ]]
+  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-detached"$'\t'"(detached)"$'\t'"detached"* ]]
+  [[ "$records" == *"0"$'\t'"$TEST_WORKTREES_DIR/records-locked"$'\t'"records-locked"$'\t'"locked"* ]]
+
+  git -C "$TEST_REPO" worktree unlock "$TEST_WORKTREES_DIR/records-locked"
+}
+
 # ── discover_repo_root from worktree ──────────────────────────────────────────
 
 @test "discover_repo_root returns main repo root when called from a worktree" {

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -159,6 +159,31 @@ teardown() {
   [ "$status" = "ok" ]
 }
 
+@test "list_worktree_records preserves registered path containing newline" {
+  if ! git -C "$TEST_REPO" worktree list --porcelain -z >/dev/null 2>&1; then
+    skip "git worktree list --porcelain -z is not available"
+  fi
+
+  local newline_path="${TEST_REPO}-external"$'\n'"newline"
+  git -C "$TEST_REPO" worktree add "$newline_path" -b newline-path --quiet
+  local expected_path
+  expected_path=$(cd "$newline_path" && pwd -P)
+
+  local records escaped_path
+  escaped_path=$(_tsv_escape_field "$expected_path")
+  records=$(list_worktree_records "$TEST_REPO")
+
+  [[ "$records" == *"path $escaped_path"$'\n'"branch newline-path"* ]]
+
+  local status
+  status=$(worktree_status "$expected_path")
+  [ "$status" = "ok" ]
+
+  resolve_worktree "newline-path" "$TEST_REPO" "$TEST_WORKTREES_DIR" ""
+  [ "$_ctx_worktree_path" = "$expected_path" ]
+  [ "$_ctx_branch" = "newline-path" ]
+}
+
 # ── discover_repo_root from worktree ──────────────────────────────────────────
 
 @test "discover_repo_root returns main repo root when called from a worktree" {

--- a/tests/core_resolve_target.bats
+++ b/tests/core_resolve_target.bats
@@ -124,6 +124,16 @@ teardown() {
   git -C "$TEST_REPO" worktree unlock "$TEST_WORKTREES_DIR/records-locked"
 }
 
+@test "worktree_status handles registered path containing tab" {
+  local tab_path="$TEST_WORKTREES_DIR/with"$'\t'"tab"
+  git -C "$TEST_REPO" worktree add "$tab_path" -b tab-path --quiet
+
+  local status
+  status=$(worktree_status "$tab_path")
+
+  [ "$status" = "ok" ]
+}
+
 # ── discover_repo_root from worktree ──────────────────────────────────────────
 
 @test "discover_repo_root returns main repo root when called from a worktree" {

--- a/tests/integration_lifecycle.bats
+++ b/tests/integration_lifecycle.bats
@@ -50,6 +50,17 @@ teardown() {
   [[ "$branches" != *"(detached)"* ]]
 }
 
+@test "list_worktree_branches uses explicit repo root outside repo" {
+  local base_dir="${TEST_REPO}-worktrees"
+  create_worktree "$base_dir" "" "outside-context" "HEAD" "none" "1" "0" "" "" >/dev/null
+  cd /tmp || false
+
+  local branches
+  branches=$(list_worktree_branches "$base_dir" "" "$TEST_REPO")
+
+  [[ "$branches" == *"outside-context"* ]]
+}
+
 @test "resolve_target finds worktree by branch name" {
   local default_branch
   default_branch=$(git rev-parse --abbrev-ref HEAD)

--- a/tests/integration_lifecycle.bats
+++ b/tests/integration_lifecycle.bats
@@ -38,6 +38,18 @@ teardown() {
   [[ "$branches" == *"test-list"* ]]
 }
 
+@test "list_worktree_branches shows nested externally-created worktree" {
+  local base_dir="${TEST_REPO}-worktrees"
+  mkdir -p "$base_dir/jsmith"
+  git -C "$TEST_REPO" worktree add "$base_dir/jsmith/my-feature" -b jsmith/my-feature --quiet
+
+  local branches
+  branches=$(list_worktree_branches "$base_dir" "")
+
+  [[ "$branches" == *"jsmith/my-feature"* ]]
+  [[ "$branches" != *"(detached)"* ]]
+}
+
 @test "resolve_target finds worktree by branch name" {
   local default_branch
   default_branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
## Summary
- add a shared `git worktree list --porcelain` inventory helper for registered worktrees
- make `git gtr list` consume that inventory so nested worktrees are shown by their real path and fake parent rows disappear
- use the same inventory for branch enumeration, resolve fallback, and `clean --merged` iteration

Fixes #177.

## Validation
- `git diff --check`
- `shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh`
- `./scripts/generate-completions.sh --check`
- `bats tests/cmd_list.bats tests/core_resolve_target.bats tests/integration_lifecycle.bats tests/cmd_copy.bats tests/cmd_clean.bats`
- `bats tests/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust registry-based detection of worktrees, including nested/external paths; branch listings now omit detached entries and preserve TSV-escaped fields.

* **Bug Fixes**
  * Deterministic sorting and clearer status reporting (ok/locked/prunable/detached). Safer removal of merged worktrees while protecting main/active worktrees and honoring skip/force/yes flows, including paths with tabs/newlines.

* **Tests**
  * Expanded unit and integration tests for listing, cleaning, copying, resolution, and branch listing with nested and externally-created worktrees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->