### PR TITLE
Block fork pull request workflow jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   shellcheck:
+    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +24,7 @@ jobs:
           shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh
 
   completions:
+    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Completions
     runs-on: ubuntu-latest
     steps:
@@ -32,6 +34,7 @@ jobs:
         run: ./scripts/generate-completions.sh --check
 
   test:
+    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Tests
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Skip GitHub Actions jobs for pull requests opened from forks.
- Keep push, merge queue, issue, and same-repository pull request behavior unchanged.

## Why
Public fork pull requests can run attacker-controlled workflow code. Skipping those jobs prevents those pull requests from reaching repository secrets through GitHub Actions.

## Validation
- Parsed the changed workflow files with `yq e '.'`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration workflow configuration for improved development efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coderabbitai/git-worktree-runner/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->