### PR TITLE
Replace Homebrew bump action with direct formula update

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -6,22 +6,46 @@ on:
 
 permissions: read-all
 
+# mislav/bump-homebrew-formula-action rejects the HTTP 303 redirects GitHub
+# now serves for tarball URLs (mislav/bump-homebrew-formula-action#340), so
+# the formula is bumped directly via the tap's contents API instead.
 jobs:
   homebrew:
     name: Bump Homebrew formula
     runs-on: ubuntu-latest
     if: ${{ !github.event.release.prerelease }}
     steps:
-      - uses: mislav/bump-homebrew-formula-action@56a283fa15557e9abaa4bdb63b8212abc68e655c # v3
-        with:
-          formula-name: git-gtr
-          formula-path: Formula/git-gtr.rb
-          homebrew-tap: coderabbitai/homebrew-tap
-          tag-name: ${{ github.event.release.tag_name }}
-          create-pullrequest: false
-          commit-message: |
-            {{formulaName}} {{version}}
-
-            Automated update from https://github.com/coderabbitai/git-worktree-runner
+      - name: Bump Formula/git-gtr.rb in coderabbitai/homebrew-tap
         env:
-          COMMITTER_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          version="${TAG_NAME#v}"
+          url="https://github.com/coderabbitai/git-worktree-runner/archive/refs/tags/${TAG_NAME}.tar.gz"
+
+          curl -fsSL --retry 3 "$url" -o release.tar.gz
+          sha256=$(sha256sum release.tar.gz | awk '{print $1}')
+
+          gh api repos/coderabbitai/homebrew-tap/contents/Formula/git-gtr.rb > formula.json
+          blob_sha=$(jq -r '.sha' formula.json)
+          jq -r '.content' formula.json | base64 -d > git-gtr.rb
+
+          if grep -qF "  url \"${url}\"" git-gtr.rb; then
+            echo "Formula already at ${TAG_NAME}; nothing to do."
+            exit 0
+          fi
+
+          sed -i "s|^  url \".*\"$|  url \"${url}\"|" git-gtr.rb
+          sed -i "s|^  sha256 \".*\"$|  sha256 \"${sha256}\"|" git-gtr.rb
+
+          grep -qF "  url \"${url}\"" git-gtr.rb
+          grep -qF "  sha256 \"${sha256}\"" git-gtr.rb
+
+          message="$(printf 'git-gtr %s\n\nAutomated update from https://github.com/coderabbitai/git-worktree-runner' "$version")"
+
+          gh api --method PUT repos/coderabbitai/homebrew-tap/contents/Formula/git-gtr.rb \
+            -f message="$message" \
+            -f content="$(base64 -w0 git-gtr.rb)" \
+            -f sha="$blob_sha"

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -3,6 +3,12 @@ name: Update Homebrew Formula
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: Release tag to bump the formula to (e.g. v2.8.0)
+        required: true
+        type: string
 
 permissions: read-all
 
@@ -18,7 +24,7 @@ jobs:
       - name: Bump Formula/git-gtr.rb in coderabbitai/homebrew-tap
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAG_NAME: ${{ github.event.release.tag_name }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag-name }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The homebrew workflow failed on the v2.8.0 release with `unexpected HTTP 303 response`. GitHub started returning 303 redirects on tarball URLs and bump-homebrew-formula-action rejects them (mislav/bump-homebrew-formula-action#340, fix unmerged, latest release predates it). The v2.8.0 formula had to be bumped by hand.

This drops the action and does the bump directly in a script step: download the release tarball, sha256 it, update url + sha256 in the tap formula via the contents API with the existing `HOMEBREW_TAP_TOKEN`. Same commit message format the action used. Skips cleanly if the formula is already at the tag, so reruns are safe. No third-party action left in the workflow.

Also adds `workflow_dispatch` with a tag-name input so a failed bump can be rerun manually instead of editing the tap by hand.

Tested every path:
- container dry-runs of the exact script: `v2.7.3` output is byte-identical to the real v2.7.3 tap commit; bad tag and unexpected formula format both exit non-zero
- live dispatches from this branch with the real secret: `v2.8.0` hits the already-current guard, `v9.9.9` fails the run on curl 404, and a `v2.7.3` → `v2.8.0` round trip wrote real commits to the tap (f177412, 04e2f45) that diff clean against the historical 2.7.3 and current 2.8.0 formulas
- `brew fetch coderabbitai/tap/git-gtr` checks out after the round trip
- actionlint clean