### PR TITLE
Run CI on fork pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,6 @@ permissions: read-all
 
 jobs:
   shellcheck:
-    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +23,6 @@ jobs:
           shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh
 
   completions:
-    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Completions
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +32,6 @@ jobs:
         run: ./scripts/generate-completions.sh --check
 
   test:
-    if: ${{ github.event.pull_request == null || github.event.pull_request.head.repo.full_name == github.repository }}
     name: Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [main]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   shellcheck:
@@ -14,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -27,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Verify completion files are up to date
         run: ./scripts/generate-completions.sh --check
@@ -36,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install BATS
         run: sudo apt-get update && sudo apt-get install -y bats


### PR DESCRIPTION
## Summary

- Run ShellCheck, completion verification, and BATS for pull requests from forks.
- Limit the workflow token to `contents: read`.
- Disable checkout credential persistence before contributor-controlled scripts execute.

## Why

The existing job guards skip all CI for external contributions, so fork pull requests can appear green without running ShellCheck or tests. Plain `pull_request` workflows are GitHub's intended unprivileged path for validating fork code.

## Security model

- Fork `pull_request` runs receive no repository secrets.
- `GITHUB_TOKEN` is limited to `contents: read`, the minimum recommended for checkout.
- `persist-credentials: false` keeps that token out of Git configuration used by subsequent scripts.
- The repository requires approval for all external contributors before workflows run.
- Jobs use GitHub-hosted ephemeral runners; no self-hosted infrastructure is exposed.

## Validation

- Resulting workflow parses as valid YAML.
- ShellCheck passes.
- Generated completion files are current.
- Merge simulation against current `main` is conflict-free.
- GitHub Actions validates the actual pull-request merge commit after each push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to improve security and ensure validation jobs run consistently for contributions from forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->