### PR TITLE
Return non-zero when git gtr rm fails

### DIFF
--- a/lib/commands/remove.sh
+++ b/lib/commands/remove.sh
@@ -14,6 +14,7 @@ cmd_remove() {
   local delete_branch="${_arg_delete_branch:-0}"
   local yes_mode="${_arg_yes:-0}"
   local force="${_arg_force:-0}"
+  local had_failure=0
 
   resolve_repo_context || exit 1
 
@@ -22,13 +23,17 @@ cmd_remove() {
   for identifier in "${_pa_positional[@]}"; do
     # Resolve target branch
     local is_main worktree_path branch_name
-    resolve_worktree "$identifier" "$repo_root" "$base_dir" "$prefix" || continue
-  
+    if ! resolve_worktree "$identifier" "$repo_root" "$base_dir" "$prefix"; then
+      had_failure=1
+      continue
+    fi
+
     is_main="$_ctx_is_main" worktree_path="$_ctx_worktree_path" branch_name="$_ctx_branch"
 
     # Cannot remove main repository
     if [ "$is_main" = "1" ]; then
       log_error "Cannot remove main repository"
+      had_failure=1
       continue
     fi
 
@@ -41,6 +46,7 @@ cmd_remove() {
       BRANCH="$branch_name"; then
       if [ "$force" -eq 0 ]; then
         log_error "Pre-remove hook failed for $branch_name. Use --force to skip hooks."
+        had_failure=1
         continue
       else
         log_warn "Pre-remove hook failed, continuing due to --force"
@@ -49,6 +55,7 @@ cmd_remove() {
 
     # Remove the worktree
     if ! remove_worktree "$worktree_path" "$force"; then
+      had_failure=1
       continue
     fi
 
@@ -73,4 +80,6 @@ cmd_remove() {
       log_warn "Post-remove hook failed for $branch_name"
     fi
   done
+
+  return "$had_failure"
 }

--- a/tests/cmd_remove.bats
+++ b/tests/cmd_remove.bats
@@ -24,15 +24,14 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
-@test "cmd_remove skips unknown branch and continues" {
-  # cmd_remove uses 'continue' for individual failures, not 'exit'
+@test "cmd_remove fails for an unknown branch" {
   run cmd_remove nonexistent
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 1 ]
 }
 
 @test "cmd_remove cannot remove main repo" {
   run cmd_remove 1
-  [ "$status" -eq 0 ]  # continues past error, doesn't exit
+  [ "$status" -eq 1 ]
   # Main repo should still exist
   [ -d "$TEST_REPO" ]
 }
@@ -56,8 +55,20 @@ teardown() {
   create_test_worktree "hook-block"
   git config --add gtr.hook.preRemove "exit 1"
   run cmd_remove hook-block
+  [ "$status" -eq 1 ]
   # Worktree should still exist (hook blocked removal)
   [ -d "$TEST_WORKTREES_DIR/hook-block" ]
+}
+
+@test "cmd_remove fails when git refuses to remove a dirty worktree" {
+  create_test_worktree "dirty-rm"
+  touch "$TEST_WORKTREES_DIR/dirty-rm/untracked"
+
+  run cmd_remove dirty-rm
+
+  [ "$status" -eq 1 ]
+  [ -d "$TEST_WORKTREES_DIR/dirty-rm" ]
+  [[ "$output" == *"contains modified or untracked files"* ]]
 }
 
 @test "cmd_remove --force skips failed pre-remove hook" {
@@ -78,6 +89,7 @@ teardown() {
   create_test_worktree "good-rm"
   # Try to remove both a nonexistent and existing worktree
   run cmd_remove nonexistent good-rm
+  [ "$status" -eq 1 ]
   # The good one should have been removed despite the bad one failing
   [ ! -d "$TEST_WORKTREES_DIR/good-rm" ]
 }

--- a/tests/cmd_remove.bats
+++ b/tests/cmd_remove.bats
@@ -29,6 +29,11 @@ teardown() {
   [ "$status" -eq 1 ]
 }
 
+@test "git gtr rm propagates a failed exit status" {
+  run env PATH="$PROJECT_ROOT/bin:$PATH" git gtr rm nonexistent
+  [ "$status" -eq 1 ]
+}
+
 @test "cmd_remove cannot remove main repo" {
   run cmd_remove 1
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary

- track failures while processing `git gtr rm` targets
- continue processing later targets, then return a non-zero exit status if any target failed
- cover the public command plus unknown targets, the main repository, pre-remove hook failures, dirty worktrees, and mixed-success batches

## Root cause

`remove_worktree` returned `1` when Git refused to remove a worktree, but `cmd_remove` handled that result with `continue` and fell through with status `0`. This made shell chains such as `git gtr rm branch && exit` run the success branch after a failed removal.

## Validation

- `bats tests/cmd_remove.bats`
- `bats tests/` (482 tests)
- `shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh`

Closes #188


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removal commands now return a failure status when any requested removal cannot be completed.
  * Invalid branches and attempts to remove the main repository are reported as failures.
  * Dirty worktrees are rejected safely and remain available, with Git’s relevant error reported.
  * When removing multiple targets, successful removals can proceed while the overall command still reports failures.
  * The removal command wrapper now correctly propagates failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->