### PR TITLE
Use preinstalled ShellCheck in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install ShellCheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Verify ShellCheck is available
+        run: shellcheck --version
 
       - name: Run ShellCheck
         run: |


### PR DESCRIPTION
## Summary

- replace the network-dependent ShellCheck installation step with an availability check
- continue running the existing repository-wide ShellCheck command unchanged

## Why

The v2.11.0 release CI stalled twice in `sudo apt-get update && sudo apt-get install -y shellcheck`, including for more than 45 minutes on the retry. GitHub's supported Ubuntu runner images already include ShellCheck, so installing it on every run adds a package-mirror dependency without improving coverage.

## Impact

ShellCheck CI starts immediately using the runner-provided binary. Test and completion jobs are unchanged. This workflow-only change does not require a product release.

## Validation

- workflow YAML parsed successfully
- `shellcheck bin/gtr bin/git-gtr lib/*.sh lib/commands/*.sh adapters/editor/*.sh adapters/ai/*.sh`
- `./scripts/generate-completions.sh --check`
